### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ With auto mode enabled, the LED can be set to automatically turn on and off at a
 - Mode: **25**
 - Parameters: [ **sunrise hour**, **sunrise minutes**, **sunset hour**, **sunset minutes**, **ramp up minutes**, **weekdays**, **brightness**, 7x **255** ]
 
-The weekdays are encoded as a sequence of 7 bits with the following structure: `Monday Thuesday Wednessday Thursday Friday Saturday Sunday`. A bit is set to 1 if the LED should be on on that day. It is only possible to set one setting per day i.e. no conflicting settings. There is also a maximum of 7 settings.
+The weekdays are encoded as a sequence of 7 bits with the following structure: `Monday Thuesday Wednesday Thursday Friday Saturday Sunday`. A bit is set to 1 if the LED should be on on that day. It is only possible to set one setting per day i.e. no conflicting settings. There is also a maximum of 7 settings.
 
 To deactivate a setting, the same command can be used but the brightness has to be set to **255**.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ python ./chihirosctl.py set-brightness <device-address> 100
 python ./chihirosctl.py add-setting <device-address> 8:00 18:00
 
 # create a setting for specific weekdays with maximum brightness of 75 and ramp up time of 30 minutes
-python ./chihirosctl.py add-setting <device-address> 9:00 18:00 --weekdays Monday --weekdays Tuesday --ramp-up-in-minutes 30 --brightness 75
+python ./chihirosctl.py add-setting <device-address> 9:00 18:00 --weekdays monday --weekdays tuesday --ramp-up-in-minutes 30 --max-brightness 75
 
 # enable auto mode to activate the created timed settings
 python ./chihirosctl.py enable-auto-mode <device-address>

--- a/commands.py
+++ b/commands.py
@@ -45,7 +45,7 @@ def _create_command_encoding(cmd_id: int, cmd_mode: int, msg_id: tuple[bytes], p
 
 
 def _encode_timestamp(ts: datetime.datetime) -> list[int]:
-    # note: day is weekday e.g. 3 for wednessday
+    # note: day is weekday e.g. 3 for wednesday
     return [ts.year - 2000, ts.month, ts.isoweekday(), ts.hour, ts.minute, ts.second]
 
 
@@ -64,7 +64,7 @@ def create_manual_setting_command(msg_id: tuple[bytes], brightness_level: int) -
 
 def create_add_auto_setting_command(msg_id: tuple[bytes], sunrise: datetime.time, sunset: datetime.time, brightness: int, ramp_up_minutes: int, weekdays: int) -> bytearray:
     """
-    weekdays: int resulting of selection bit mask (Monday Thuesday Wednessday Thursday Friday Saturday Sunday) in decimal
+    weekdays: int resulting of selection bit mask (Monday Tuesday Wednesday Thursday Friday Saturday Sunday) in decimal
     """
     parameters = [sunrise.hour, sunrise.minute, sunset.hour, sunset.minute,
                   ramp_up_minutes, weekdays, brightness, 255, 255, 255, 255, 255, 255, 255]

--- a/weekday_encoding.py
+++ b/weekday_encoding.py
@@ -3,7 +3,7 @@ from enum import Enum
 class WeekdaySelect(str, Enum):
     monday = "monday"
     tuesday = "tuesday"
-    wednessday = "wednessday"
+    wednesday = "wednesday"
     thursday = "thursday"
     friday = "friday"
     saturday = "saturday"
@@ -19,7 +19,7 @@ def encode_selected_weekdays(selection: list[WeekdaySelect]) -> int:
         encoding += 64
     if WeekdaySelect.tuesday in selection:
         encoding += 32
-    if WeekdaySelect.wednessday in selection:
+    if WeekdaySelect.wednesday in selection:
         encoding += 16
     if WeekdaySelect.thursday in selection:
         encoding += 8


### PR DESCRIPTION
Update example in `README.md` to match argument parsing and fix spelling of some weekdays.