### PR TITLE
Add support for RGB lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ The command length is the number of parameters + 5.
 The LED can be set to a specific brightness by sending the following command with the following options:
 - Command ID: **90**
 - Mode: **7**
-- Parameters: [ **Color** (0), **Brightness** (0 - 100)]
+- Parameters: [ **Color** (0-2), **Brightness** (0 - 100)]
 
+On non-RGB models, the color parameter should be set to 0 to indicate white. On RGB models, each color's brightness is sent as a separate command. Red is 0, green is 1, blue is 2.
 
 ### Auto Mode
 To switch to auto mode, the following command can be used:
@@ -78,9 +79,11 @@ With auto mode enabled, the LED can be set to automatically turn on and off at a
 
 - Command ID: **165**
 - Mode: **25**
-- Parameters: [ **sunrise hour**, **sunrise minutes**, **sunset hour**, **sunset minutes**, **ramp up minutes**, **weekdays**, **brightness**, 7x **255** ]
+- Parameters: [ **sunrise hour**, **sunrise minutes**, **sunset hour**, **sunset minutes**, **ramp up minutes**, **weekdays**, **red brightness**, **green brightness**, **blue brightness**, 5x **255** ]
 
 The weekdays are encoded as a sequence of 7 bits with the following structure: `Monday Thuesday Wednesday Thursday Friday Saturday Sunday`. A bit is set to 1 if the LED should be on on that day. It is only possible to set one setting per day i.e. no conflicting settings. There is also a maximum of 7 settings.
+
+On non-RGB models, the desired brightness should be set as the red brightness while the other two colors should be set to **255**.
 
 To deactivate a setting, the same command can be used but the brightness has to be set to **255**.
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains an example python CLI script that can be used to contro
 
 ## Supported Devices
 - [Chihiros LED A2](https://www.chihirosaquaticstudio.com/products/chihiros-a-ii-built-in-bluetooth)
+- [Chihiros WRGB II](https://www.chihirosaquaticstudio.com/products/chihiros-wrgb-ii-led-built-in-bluetooth)
 - other LED models might work as well but are not tested
 
 ## Requirements
@@ -32,6 +33,17 @@ python ./chihirosctl.py add-setting <device-address> 8:00 18:00
 
 # create a setting for specific weekdays with maximum brightness of 75 and ramp up time of 30 minutes
 python ./chihirosctl.py add-setting <device-address> 9:00 18:00 --weekdays monday --weekdays tuesday --ramp-up-in-minutes 30 --max-brightness 75
+
+# on RGB models, use the RGB versions of the above commands
+
+# manually set the brightness to 60 red, 80 green, 100 blue on RGB models
+python ./chihirosctl.py set-rgb-brightness <device-address> 60 80 100
+
+# create an automatic timed setting that turns on the light from 8:00 to 18:00
+python ./chihirosctl.py add-rgb-setting <device-address> 8:00 18:00
+
+# create a setting for specific weekdays with maximum brightness of 35, 55, 75 and ramp up time of 30 minutes
+python ./chihirosctl.py add-rgb-setting <device-address> 9:00 18:00 --weekdays monday --weekdays tuesday --ramp-up-in-minutes 30 --max-brightness 35 55 75
 
 # enable auto mode to activate the created timed settings
 python ./chihirosctl.py enable-auto-mode <device-address>

--- a/chihirosctl.py
+++ b/chihirosctl.py
@@ -34,6 +34,15 @@ def set_brightness(device_address: str, brightness: Annotated[int, typer.Argumen
     asyncio.run(_execute_command(device_address, cmd))
 
 @app.command()
+def set_rgb_brightness(device_address: str, brightness: Annotated[tuple[int, int, int], typer.Argument()]):
+    global msg_id
+    cmds = []
+    for c, b in enumerate(brightness):
+        cmds.append(commands.create_manual_setting_command(msg_id, c, b))
+        msg_id = commands.next_message_id(msg_id)
+    asyncio.run(_execute_command(device_address, *cmds))
+
+@app.command()
 def add_setting(device_address: str, 
                      sunrise: Annotated[datetime, typer.Argument(formats=["%H:%M"])],
                      sunset: Annotated[datetime, typer.Argument(formats=["%H:%M"])], 
@@ -41,6 +50,16 @@ def add_setting(device_address: str,
                      ramp_up_in_minutes: Annotated[int, typer.Option(min=0, max=150)] = 0, 
                      weekdays: Annotated[List[WeekdaySelect], typer.Option()] = [WeekdaySelect.everyday]):    
     cmd = commands.create_add_auto_setting_command(msg_id, sunrise.time(), sunset.time(), (max_brightness, 255, 255), ramp_up_in_minutes, encode_selected_weekdays(weekdays))
+    asyncio.run(_execute_command(device_address, cmd))
+
+@app.command()
+def add_rgb_setting(device_address: str,
+                         sunrise: Annotated[datetime, typer.Argument(formats=["%H:%M"])],
+                         sunset: Annotated[datetime, typer.Argument(formats=["%H:%M"])],
+                         max_brightness: Annotated[tuple[int, int, int], typer.Option()] = (100, 100, 100),
+                         ramp_up_in_minutes: Annotated[int, typer.Option(min=0, max=150)] = 0,
+                         weekdays: Annotated[List[WeekdaySelect], typer.Option()] = [WeekdaySelect.everyday]):
+    cmd = commands.create_add_auto_setting_command(msg_id, sunrise.time(), sunset.time(), max_brightness, ramp_up_in_minutes, encode_selected_weekdays(weekdays))
     asyncio.run(_execute_command(device_address, cmd))
 
 @app.command()

--- a/chihirosctl.py
+++ b/chihirosctl.py
@@ -30,7 +30,7 @@ def list_devices(timeout: Annotated[int, typer.Option()] = 5):
 
 @app.command()
 def set_brightness(device_address: str, brightness: Annotated[int, typer.Argument(min=0, max=100)]):
-    cmd = commands.create_manual_setting_command(msg_id, brightness)
+    cmd = commands.create_manual_setting_command(msg_id, 0, brightness)
     asyncio.run(_execute_command(device_address, cmd))
 
 @app.command()
@@ -40,7 +40,7 @@ def add_setting(device_address: str,
                      max_brightness: Annotated[int, typer.Option(max=100, min=0)] = 100,
                      ramp_up_in_minutes: Annotated[int, typer.Option(min=0, max=150)] = 0, 
                      weekdays: Annotated[List[WeekdaySelect], typer.Option()] = [WeekdaySelect.everyday]):    
-    cmd = commands.create_add_auto_setting_command(msg_id, sunrise.time(), sunset.time(), max_brightness, ramp_up_in_minutes, encode_selected_weekdays(weekdays))
+    cmd = commands.create_add_auto_setting_command(msg_id, sunrise.time(), sunset.time(), (max_brightness, 255, 255), ramp_up_in_minutes, encode_selected_weekdays(weekdays))
     asyncio.run(_execute_command(device_address, cmd))
 
 @app.command()

--- a/commands.py
+++ b/commands.py
@@ -53,27 +53,29 @@ def create_set_time_command(msg_id: tuple[bytes]) -> bytearray:
     return _create_command_encoding(90, 9, msg_id, _encode_timestamp(datetime.datetime.now()))
 
 
-def create_manual_setting_command(msg_id: tuple[bytes], brightness_level: int) -> bytearray:
+def create_manual_setting_command(msg_id: tuple[bytes], color: int, brightness_level: int) -> bytearray:
     """
     set brightness
+    param: color: 0-2 (0 is red, 1 is green, 2 is blue; on non-RGB models, 0 is white)
     param: brightness_level: 0 - 100
     """
-    color = 0  # white
     return _create_command_encoding(90, 7, msg_id, [color, brightness_level])
 
 
-def create_add_auto_setting_command(msg_id: tuple[bytes], sunrise: datetime.time, sunset: datetime.time, brightness: int, ramp_up_minutes: int, weekdays: int) -> bytearray:
+def create_add_auto_setting_command(msg_id: tuple[bytes], sunrise: datetime.time, sunset: datetime.time, brightness: tuple[int, int, int], ramp_up_minutes: int, weekdays: int) -> bytearray:
     """
+    brightness: tuple of 3 ints for red, green, and blue brightness, respectively
+                on non-RGB models, set to (white brightness, 255, 255)
     weekdays: int resulting of selection bit mask (Monday Tuesday Wednesday Thursday Friday Saturday Sunday) in decimal
     """
     parameters = [sunrise.hour, sunrise.minute, sunset.hour, sunset.minute,
-                  ramp_up_minutes, weekdays, brightness, 255, 255, 255, 255, 255, 255, 255]
+                  ramp_up_minutes, weekdays, *brightness, 255, 255, 255, 255, 255]
 
     return _create_command_encoding(165, 25, msg_id, parameters)
 
 
 def create_delete_auto_setting_command(msg_id: tuple[bytes], sunrise: datetime.time, sunset: datetime.time, ramp_up_minutes: int, weekdays: int) -> bytearray:
-    return create_add_auto_setting_command(msg_id, sunrise, sunset, 255, ramp_up_minutes, weekdays)
+    return create_add_auto_setting_command(msg_id, sunrise, sunset, (255, 255, 255), ramp_up_minutes, weekdays)
 
 
 def create_reset_auto_settings_command(msg_id: tuple[bytes]) -> bytearray:


### PR DESCRIPTION
Thank you for open sourcing this project and for the detailed protocol documentation. With them, I was able to sniff the commands sent to my Chihiros WRGB II and make the following changes to support RGB:

* Update `create_manual_setting_command` to take a color argument; it should be called once for each color channel
* Update the `max_brightness` argument in `create_add_auto_setting_command` to be a tuple of 3 `int`s, one for each color channel
* Update existing `set-brightness` and `add-setting` commands for the above changes
* Add new RGB versions of the above commands: `set-rgb-brightness` and `add-rgb-setting`
* Update `README.md` with RGB protocol notes and document the new commands