### PR TITLE
Improve HA support

### DIFF
--- a/custom_components/chihiros/manifest.json
+++ b/custom_components/chihiros/manifest.json
@@ -52,8 +52,6 @@
   "iot_class": "assumed_state",
   "issue_tracker": "https://github.com/TheMicDiet/chihiros-led-control/issues",
   "requirements": [
-    "bleak==0.21.1",
-    "bleak_retry_connector==3.5.0",
     "typer[all]==0.9.0"
   ],
   "version": "0.2.1"


### PR DESCRIPTION
Remove hard corded dependency versions to make the integration works with all the version of HA.
The removed dependencies are provided by HA itself.
I copy the behavior from another integration: https://github.com/fuatakgun/generic_bt/blob/main/custom_components/generic_bt/manifest.json