### PR TITLE
update model codes for wrgb2 slim (120 cm variant)

### DIFF
--- a/custom_components/chihiros/chihiros_led_control/device/wrgb2_slim.py
+++ b/custom_components/chihiros/chihiros_led_control/device/wrgb2_slim.py
@@ -7,7 +7,7 @@ class WRGBIISlim(BaseDevice):
     """Chihiros WRGB II Slim device Class."""
 
     _model_name = "WRGB II Slim"
-    _model_codes = ["DYSILN", "DYSL30", "DYSL45", "DYSL60", "DYSL90", "DYSL120"]
+    _model_codes = ["DYSILN", "DYSL30", "DYSL45", "DYSL60", "DYSL90", "DYSL12"]
     _colors: dict[str, int] = {
         "red": 0,
         "green": 1,


### PR DESCRIPTION
Based on serial number of my Chihiros WRGB II Slim 120 cm, the right code is DYSL12 (without zero).

The serial number is DYSL12ECE3708ACF8D

Fix #77