### PR TITLE
fix: relax bleak version pin for Python 3.14 compatibility

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ url = https://github.com/TheMicDiet/chihiros-led-control
 # https://github.com/renovatebot/renovate/issues/10187
 [options]
 install_requires =
-    bleak==0.22.3
+    bleak>=0.22.3
     bleak_retry_connector==3.9.0
     typer[all]==0.15.2
     rich==13.9.4


### PR DESCRIPTION
fix: relax bleak version pin for Python 3.14 compatibility