### PR TITLE
Make device list model detection reliable again

### DIFF
--- a/custom_components/chihiros/chihiros_led_control/chihirosctl.py
+++ b/custom_components/chihiros/chihiros_led_control/chihirosctl.py
@@ -46,8 +46,9 @@ def list_devices(timeout: Annotated[int, typer.Option()] = 5) -> None:
         model_name = "???"
         if device.name is not None:
             model_class = get_model_class_from_name(device.name)
-            if model_class.model_code:  # type: ignore
-                model_name = model_class.model_name  # type: ignore
+            model_codes = getattr(model_class, "model_codes", [])
+            if model_codes:
+                model_name = model_class.model_name or model_name  # type: ignore
         table.add_row(device.name, device.address, model_name)
     print("Discovered the following devices:")
     print(table)


### PR DESCRIPTION
When listing Bluetooth devices, model names were not detected correctly in some cases and could remain ??? even for supported Chihiros devices.
The root cause was a check against an unsuitable single model attribute.

This fix updates the detection logic to validate the actual model codes used by devices.
As a result, supported devices are now shown with the correct model name again, while unknown devices are still consistently displayed as ???.