### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   main:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/TheMicDiet/chihiros-led-control/security/code-scanning/5](https://github.com/TheMicDiet/chihiros-led-control/security/code-scanning/5)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is restricted.  
For this workflow, the best minimal fix is at the workflow root (applies to all jobs): `contents: read`. This preserves existing functionality (`actions/checkout` and running `pre-commit`) while preventing unintended write privileges.

Edit `.github/workflows/pre-commit.yaml` by inserting:

```yaml
permissions:
  contents: read
```

between `on`/trigger section and `jobs` (or directly under `name`/`on` as valid YAML structure). No imports, methods, or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
