### PR TITLE
Add WRGB VIVID III support with fan control

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This repository contains a python **CLI** script as well as a **Home Assistant i
 ## Supported Devices
 - [Chihiros LED A2](https://www.chihirosaquaticstudio.com/products/chihiros-a-ii-built-in-bluetooth)
 - [Chihiros WRGB II](https://www.chihirosaquaticstudio.com/products/chihiros-wrgb-ii-led-built-in-bluetooth) (Regular, Pro, Slim; Pro is true WRGB)
+- Chihiros WRGB VIVID III (true WRGB, including fan speed control and fan RPM/temperature sensors)
 - Chihiros Tiny Terrarium Egg
 - Chihiros C II (RGB, White)
 - Chihiros Universal WRGB

--- a/custom_components/chihiros/__init__.py
+++ b/custom_components/chihiros/__init__.py
@@ -99,7 +99,14 @@ __all__ = [
     "async_trigger_dose_ml",
 ]
 
-PLATFORMS: list[Platform] = [Platform.LIGHT, Platform.SWITCH, Platform.SENSOR, Platform.NUMBER, Platform.BUTTON]
+PLATFORMS: list[Platform] = [
+    Platform.LIGHT,
+    Platform.SWITCH,
+    Platform.SENSOR,
+    Platform.NUMBER,
+    Platform.BUTTON,
+    Platform.FAN,
+]
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/chihiros/coordinator.py
+++ b/custom_components/chihiros/coordinator.py
@@ -13,6 +13,7 @@ from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
 
 from .runtime import ChihirosClient
 from .vendor.chihiros_led_control.protocol import (
+    FanStatusNotification,
     ParsedNotification,
     RuntimeNotification,
     SchedulePoint,
@@ -26,6 +27,8 @@ ATTR_RUNTIME_NOTIFICATION = "runtime_notification"
 ATTR_RUNTIME_NOTIFICATION_PAYLOAD = "runtime_notification_payload"
 ATTR_LAST_NOTIFICATION = "last_notification"
 ATTR_SCHEDULE_POINTS = "schedule_points"
+ATTR_FAN_RPM = "fan_rpm"
+ATTR_FAN_TEMPERATURE_CELSIUS = "fan_temperature_celsius"
 
 
 class ChihirosDataUpdateCoordinator(PassiveBluetoothDataUpdateCoordinator):
@@ -103,6 +106,11 @@ class ChihirosDataUpdateCoordinator(PassiveBluetoothDataUpdateCoordinator):
             self.data[ATTR_RUNTIME_NOTIFICATION] = notification.raw.hex(" ")
             self.data[ATTR_RUNTIME_NOTIFICATION_PAYLOAD] = notification.raw[6:].hex(" ")
             self.data[ATTR_LAST_NOTIFICATION] = _notification_to_debug_dict(notification, "runtime")
+        elif isinstance(notification, FanStatusNotification):
+            self.data[ATTR_FIRMWARE_VERSION] = notification.firmware_version
+            self.data[ATTR_FAN_RPM] = notification.fan_rpm
+            self.data[ATTR_FAN_TEMPERATURE_CELSIUS] = notification.temperature_celsius
+            self.data[ATTR_LAST_NOTIFICATION] = _notification_to_debug_dict(notification, "fan_status")
         elif isinstance(notification, ScheduleSnapshotNotification):
             self.data[ATTR_FIRMWARE_VERSION] = notification.firmware_version
             self.data[ATTR_SCHEDULE_POINTS] = tuple(_schedule_point_to_dict(point) for point in notification.points)
@@ -135,7 +143,7 @@ def _schedule_point_to_dict(point: SchedulePoint) -> dict[str, Any]:
 
 
 def _notification_to_debug_dict(
-    notification: RuntimeNotification | ScheduleSnapshotNotification,
+    notification: RuntimeNotification | FanStatusNotification | ScheduleSnapshotNotification,
     parsed_type: str,
 ) -> dict[str, Any]:
     """Return a Home Assistant-friendly raw notification diagnostic payload."""

--- a/custom_components/chihiros/fake.py
+++ b/custom_components/chihiros/fake.py
@@ -11,6 +11,7 @@ from datetime import datetime
 from .dosing import normalize_pump_count
 from .vendor.chihiros_led_control.models import DOSING_PUMP, RGB_CHANNELS, WHITE_CHANNELS, WRGB_CHANNELS, DeviceModel
 from .vendor.chihiros_led_control.protocol import (
+    FanStatusNotification,
     ParsedNotification,
     RuntimeNotification,
     SchedulePoint,
@@ -50,6 +51,11 @@ FAKE_DEVICES = (
         address=f"{FAKE_ADDRESS_PREFIX}:00:00:04",
         name="DYDOSE-fake",
         model=DOSING_PUMP,
+    ),
+    FakeChihirosDeviceInfo(
+        address=f"{FAKE_ADDRESS_PREFIX}:00:00:05",
+        name="DYVVD3-fake",
+        model=DeviceModel("Fake WRGB VIVID III", ("DYVVD3",), WRGB_CHANNELS, has_fan=True),
     ),
 )
 FAKE_DEVICES_BY_ADDRESS = {device.address: device for device in FAKE_DEVICES}
@@ -92,7 +98,9 @@ class FakeChihirosDevice:
         self._brightness = {color: 0 for color in self.model.color_channels}
         self._dosed_ml = [0.0] * self.pump_count
         self._auto_mode = False
+        self._fan_speed = 0
         self.last_runtime_notification: RuntimeNotification | None = None
+        self.last_fan_status_notification: FanStatusNotification | None = None
         self.last_schedule_snapshot_notification: ScheduleSnapshotNotification | None = None
 
     @property
@@ -176,6 +184,21 @@ class FakeChihirosDevice:
         """Enable fake manual mode."""
         self._auto_mode = False
         await self.turn_on()
+
+    async def set_fan_speed(self, speed_percent: int) -> None:
+        """Set fake fan speed and publish a fake fan status notification."""
+        await asyncio.sleep(0)
+        if not self.model.has_fan:
+            raise ValueError(f"Model does not support fan control: {self.model.name}")
+        if speed_percent < 0 or speed_percent > 100:
+            raise ValueError("Fan speed must be between 0 and 100 percent")
+        self._fan_speed = speed_percent
+        self.last_fan_status_notification = FanStatusNotification(
+            firmware_version=27,
+            fan_rpm=speed_percent * 20,
+            temperature_celsius=25,
+        )
+        self._notify_callbacks(self.last_fan_status_notification)
 
     async def add_setting(
         self,

--- a/custom_components/chihiros/fan.py
+++ b/custom_components/chihiros/fan.py
@@ -1,0 +1,129 @@
+"""Fan platform for fan-equipped Chihiros devices such as the WRGB VIVID III."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.bluetooth.passive_update_coordinator import (
+    PassiveBluetoothCoordinatorEntity,
+)
+from homeassistant.components.fan import FanEntity, FanEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
+
+from .const import DOMAIN
+from .coordinator import ATTR_FAN_RPM, ChihirosDataUpdateCoordinator
+from .entity import chihiros_device_info, chihiros_entity_name, chihiros_unique_id
+from .models import ChihirosData
+from .runtime import ChihirosClient
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the fan platform for fan-equipped Chihiros devices."""
+    chihiros_data: ChihirosData = hass.data[DOMAIN][entry.entry_id]
+    if not chihiros_data.device.model.has_fan:
+        return
+    async_add_entities(
+        [
+            ChihirosFanEntity(
+                chihiros_data.coordinator,
+                chihiros_data.device,
+            )
+        ]
+    )
+
+
+class ChihirosFanEntity(
+    PassiveBluetoothCoordinatorEntity[ChihirosDataUpdateCoordinator],
+    FanEntity,
+    RestoreEntity,
+):
+    """Representation of a Chihiros device fan."""
+
+    _attr_assumed_state = True
+    _attr_should_poll = False
+    _attr_supported_features = FanEntityFeature.SET_SPEED
+
+    def __init__(
+        self,
+        coordinator: ChihirosDataUpdateCoordinator,
+        chihiros_device: ChihirosClient,
+    ) -> None:
+        """Initialize the fan entity."""
+        super().__init__(coordinator)
+        self._device = chihiros_device
+        self._address = coordinator.address
+        self._attr_name = chihiros_entity_name(self._device, "Fan")
+        self._attr_unique_id = chihiros_unique_id(self._address, "fan")
+        self._attr_device_info = chihiros_device_info(self._device, self._address)
+        self._attr_percentage = 0
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity about to be added to hass event."""
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            self._attr_percentage = last_state.attributes.get("percentage") or 0
+
+    @property
+    def available(self) -> bool:
+        """Return whether the fan is available."""
+        if self.coordinator.always_available:
+            return True
+        return super().available
+
+    @property
+    def is_on(self) -> bool:
+        """Return whether the fan is running."""
+        return bool(self._attr_percentage and self._attr_percentage > 0)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any] | None:
+        """Return the measured fan RPM reported by status notifications."""
+        fan_rpm = self.coordinator.data.get(ATTR_FAN_RPM)
+        if fan_rpm is None:
+            return None
+        return {ATTR_FAN_RPM: fan_rpm}
+
+    async def async_set_percentage(self, percentage: int) -> None:
+        """Set the fan speed percentage."""
+        _LOGGER.debug("Setting fan speed: %s to %s%%", self.name, percentage)
+        await self._set_fan_speed(percentage)
+        self._attr_percentage = percentage
+        self.schedule_update_ha_state()
+
+    async def async_turn_on(
+        self,
+        percentage: int | None = None,
+        preset_mode: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        """Turn on the fan."""
+        del preset_mode, kwargs
+        if percentage is None:
+            percentage = self._attr_percentage or 100
+        await self.async_set_percentage(percentage)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Turn off the fan."""
+        del kwargs
+        await self.async_set_percentage(0)
+
+    async def _set_fan_speed(self, percentage: int) -> None:
+        """Send the fan speed command and keep availability in sync."""
+        try:
+            await self._device.set_fan_speed(percentage)
+        except Exception as ex:
+            self._attr_available = False
+            self.schedule_update_ha_state()
+            raise HomeAssistantError(f"Failed to set fan speed for {self.name}") from ex
+        self._attr_available = True

--- a/custom_components/chihiros/manifest.json
+++ b/custom_components/chihiros/manifest.json
@@ -96,5 +96,5 @@
   "iot_class": "assumed_state",
   "issue_tracker": "https://github.com/TheMicDiet/chihiros-led-control/issues",
   "requirements": [],
-  "version": "0.11.4"
+  "version": "0.12.0"
 }

--- a/custom_components/chihiros/runtime.py
+++ b/custom_components/chihiros/runtime.py
@@ -17,7 +17,12 @@ from .dosing import CONF_PUMP_COUNT, normalize_pump_count
 from .fake import create_fake_device, fake_devices_enabled, is_fake_address
 from .vendor.chihiros_led_control import create_device, needs_device_type
 from .vendor.chihiros_led_control.models import DeviceModel
-from .vendor.chihiros_led_control.protocol import ParsedNotification, RuntimeNotification, ScheduleSnapshotNotification
+from .vendor.chihiros_led_control.protocol import (
+    FanStatusNotification,
+    ParsedNotification,
+    RuntimeNotification,
+    ScheduleSnapshotNotification,
+)
 from .vendor.chihiros_led_control.weekday_encoding import WeekdaySelect
 
 NotificationCallback = Callable[[ParsedNotification], None]
@@ -35,6 +40,7 @@ class ChihirosClient(Protocol):
 
     model: DeviceModel
     last_runtime_notification: RuntimeNotification | None
+    last_fan_status_notification: FanStatusNotification | None
     last_schedule_snapshot_notification: ScheduleSnapshotNotification | None
 
     @property
@@ -73,6 +79,9 @@ class ChihirosClient(Protocol):
 
     async def set_manual_mode(self) -> None:
         """Enable manual mode."""
+
+    async def set_fan_speed(self, speed_percent: int) -> None:
+        """Set the fan speed percentage on fan-equipped models."""
 
     async def add_setting(
         self,

--- a/custom_components/chihiros/sensor.py
+++ b/custom_components/chihiros/sensor.py
@@ -8,9 +8,14 @@ from typing import Any
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
 )
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorEntityDescription
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfVolume
+from homeassistant.const import REVOLUTIONS_PER_MINUTE, UnitOfTemperature, UnitOfVolume
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -19,6 +24,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (
+    ATTR_FAN_RPM,
+    ATTR_FAN_TEMPERATURE_CELSIUS,
     ATTR_FIRMWARE_VERSION,
     ATTR_LAST_NOTIFICATION,
     ATTR_SCHEDULE_POINTS,
@@ -45,6 +52,24 @@ SENSOR_DESCRIPTIONS = (
     SensorEntityDescription(
         key=ATTR_LAST_NOTIFICATION,
         name="Last Notification",
+    ),
+)
+
+FAN_SENSOR_DESCRIPTIONS = (
+    SensorEntityDescription(
+        key=ATTR_FAN_RPM,
+        name="Fan Speed",
+        native_unit_of_measurement=REVOLUTIONS_PER_MINUTE,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
+    ),
+    SensorEntityDescription(
+        key=ATTR_FAN_TEMPERATURE_CELSIUS,
+        name="Temperature",
+        device_class=SensorDeviceClass.TEMPERATURE,
+        native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+        state_class=SensorStateClass.MEASUREMENT,
+        suggested_display_precision=0,
     ),
 )
 
@@ -76,6 +101,16 @@ async def async_setup_entry(
         )
         for description in SENSOR_DESCRIPTIONS
     )
+    if chihiros_data.device.model.has_fan:
+        async_add_entities(
+            ChihirosNotificationSensor(
+                chihiros_data.coordinator,
+                chihiros_data.device,
+                description,
+                entity_category=None,
+            )
+            for description in FAN_SENSOR_DESCRIPTIONS
+        )
     hass.async_create_task(_async_request_initial_status(chihiros_data.coordinator))
 
 
@@ -101,6 +136,7 @@ class ChihirosNotificationSensor(
         coordinator: ChihirosDataUpdateCoordinator,
         device: ChihirosClient,
         description: SensorEntityDescription,
+        entity_category: EntityCategory | None = EntityCategory.DIAGNOSTIC,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -111,6 +147,8 @@ class ChihirosNotificationSensor(
         self._attr_device_info = chihiros_device_info(device, coordinator.address)
         self._attr_device_class = description.device_class
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
+        self._attr_state_class = description.state_class
+        self._attr_entity_category = entity_category
 
     @property
     def available(self) -> bool:

--- a/custom_components/chihiros/vendor/chihiros_led_control/client.py
+++ b/custom_components/chihiros/vendor/chihiros_led_control/client.py
@@ -27,6 +27,7 @@ from .const import UART_RX_CHAR_UUID, UART_TX_CHAR_UUID
 from .exceptions import CharacteristicMissingError
 from .models import FALLBACK, DeviceModel
 from .protocol import (
+    FanStatusNotification,
     ParsedNotification,
     RuntimeNotification,
     ScheduleSnapshotNotification,
@@ -69,6 +70,7 @@ class ChihirosDevice:
         self._msg_id = next_message_id()
         self._notification_callbacks: set[NotificationCallback] = set()
         self.last_runtime_notification: RuntimeNotification | None = None
+        self.last_fan_status_notification: FanStatusNotification | None = None
         self.last_schedule_snapshot_notification: ScheduleSnapshotNotification | None = None
         self.loop = asyncio.get_running_loop()
 
@@ -221,6 +223,13 @@ class ChihirosDevice:
         cmd = commands.create_query_status_command(self.get_next_msg_id())
         await self._send_command(cmd, 3, notification_wait=STATUS_NOTIFICATION_WAIT)
 
+    async def set_fan_speed(self, speed_percent: int) -> None:
+        """Set the fan speed percentage on fan-equipped models."""
+        if not self.model.has_fan:
+            raise ValueError(f"Model does not support fan control: {self.model.name}")
+        cmd = commands.create_set_fan_speed_command(self.get_next_msg_id(), speed_percent)
+        await self._send_command(cmd, 3)
+
     async def add_setting(
         self,
         sunrise: datetime,
@@ -345,6 +354,17 @@ class ChihirosDevice:
                 self.name,
                 parsed.firmware_version,
                 parsed.runtime_minutes,
+            )
+            self._notify_callbacks(parsed)
+            return
+        if isinstance(parsed, FanStatusNotification):
+            self.last_fan_status_notification = parsed
+            self._logger.debug(
+                "%s: Fan status notification received; firmware=%s fan_rpm=%s temperature_celsius=%s",
+                self.name,
+                parsed.firmware_version,
+                parsed.fan_rpm,
+                parsed.temperature_celsius,
             )
             self._notify_callbacks(parsed)
             return

--- a/custom_components/chihiros/vendor/chihiros_led_control/commands.py
+++ b/custom_components/chihiros/vendor/chihiros_led_control/commands.py
@@ -116,3 +116,10 @@ def create_reset_auto_settings_command(msg_id: tuple[int, int]) -> bytearray:
 def create_switch_to_auto_mode_command(msg_id: tuple[int, int]) -> bytearray:
     """Create a switch to auto mode command."""
     return create_command_encoding(90, 5, msg_id, [18, 255, 255])
+
+
+def create_set_fan_speed_command(msg_id: tuple[int, int], speed_percent: int) -> bytearray:
+    """Create a fan speed command for fan-equipped LED devices such as the WRGB VIVID III."""
+    if speed_percent < 0 or speed_percent > 100:
+        raise ValueError("Fan speed must be between 0 and 100 percent")
+    return create_command_encoding(90, 15, msg_id, [speed_percent])

--- a/custom_components/chihiros/vendor/chihiros_led_control/models.py
+++ b/custom_components/chihiros/vendor/chihiros_led_control/models.py
@@ -16,6 +16,7 @@ class DeviceModel:
     color_channels: Mapping[str, int]
     needs_device_type: bool = False
     fallback: bool = False
+    has_fan: bool = False
 
 
 WHITE_CHANNELS = MappingProxyType({"white": 0})
@@ -51,6 +52,7 @@ SUPPORTED_MODELS: tuple[DeviceModel, ...] = (
         ("DYSILN", "DYSL30", "DYSL45", "DYSL60", "DYSL90", "DYSL120", "DYSL12"),
         RGB_CHANNELS,
     ),
+    DeviceModel("WRGB VIVID III", ("DYVVD3",), WRGB_CHANNELS, has_fan=True),
     DeviceModel("C II", ("DYNC2N",), WHITE_CHANNELS),
     DeviceModel("C II RGB", ("DYNCRGP", "DYNCRGB"), RGB_CHANNELS),
     DeviceModel(

--- a/custom_components/chihiros/vendor/chihiros_led_control/protocol.py
+++ b/custom_components/chihiros/vendor/chihiros_led_control/protocol.py
@@ -21,6 +21,16 @@ class RuntimeNotification:
 
 
 @dataclass(frozen=True)
+class FanStatusNotification:
+    """Parsed fan-equipped device status notification."""
+
+    firmware_version: int
+    fan_rpm: int
+    temperature_celsius: int
+    raw: bytes = field(default=b"", compare=False)
+
+
+@dataclass(frozen=True)
 class SchedulePoint:
     """Parsed auto schedule point."""
 
@@ -38,7 +48,7 @@ class ScheduleSnapshotNotification:
     raw: bytes = field(default=b"", compare=False)
 
 
-ParsedNotification = RuntimeNotification | ScheduleSnapshotNotification
+ParsedNotification = RuntimeNotification | FanStatusNotification | ScheduleSnapshotNotification
 
 
 def next_message_id(current_msg_id: tuple[int, int] = (0, 0)) -> tuple[int, int]:
@@ -133,6 +143,11 @@ def parse_notification(
     if mode == 0x0A and len(data) >= 8:
         runtime_minutes = (data[6] << 8) | data[7]
         return RuntimeNotification(firmware_version, runtime_minutes, bytes(data))
+
+    if mode == 0x0B and len(data) >= 9:
+        fan_rpm = (data[6] << 8) | data[7]
+        temperature_celsius = data[8]
+        return FanStatusNotification(firmware_version, fan_rpm, temperature_celsius, bytes(data))
 
     if mode == 0xFE:
         if color_channels is None:

--- a/docs/a2-custom-schedule-protocol.md
+++ b/docs/a2-custom-schedule-protocol.md
@@ -1,0 +1,186 @@
+# A2 Custom Schedule Protocol
+
+This note records BLE traffic captured from a single-channel Chihiros A2 while
+the official app created custom brightness schedules. It is intended as a
+reference for adding custom-curve support later. The behavior described here is
+not implemented by the library yet.
+
+## Capture Context
+
+The capture was recorded on 2026-07-11 while creating two profiles:
+
+1. A curve shown in the app as starting at `08:00` at `0%`, increasing to
+   `40%` at `11:00`, and dropping to `0%` at `12:00`.
+2. A profile intended to remain at `10%` throughout the day.
+
+The A2 has one white channel. Application data was transported over the Nordic
+UART service documented in [protocol.md](protocol.md).
+
+## Custom Curve Point Command
+
+The app writes custom curve points using command family `0x5a`, mode `0x06`:
+
+```text
+5a 01 09 msg_hi msg_lo 06 channel hour minute level checksum
+```
+
+The four parameters are:
+
+| Offset | Name | Observed value or range |
+| ---: | --- | --- |
+| `6` | Channel | `0` for the A2 white channel |
+| `7` | Hour | `0..23` |
+| `8` | Minute | `0..59` |
+| `9` | Brightness level | `0..100` percent |
+
+The command-length byte is `0x09`, corresponding to four parameters plus five.
+The final byte uses the normal XOR checksum.
+
+Example for channel `0`, `08:00`, `10%`:
+
+```text
+5a 01 09 00 ca 06 00 08 00 0a c6
+```
+
+This is a distinct `0x5a / 0x06` format from the older three-parameter
+`[channel, time_index, level]` form. Implementations must select the format by
+device/model capability; they must not assume every `0x5a / 0x06` device uses
+the same payload length.
+
+## Custom Schedule Setup Sequence
+
+Immediately before committing a custom curve, the app sends two `0x5a / 0x05`
+commands:
+
+```text
+5a / 05 [05, ff, ff]  clear or reset the current custom schedule
+5a / 05 [03, ff, ff]  initialize or select custom-curve mode
+```
+
+The meaning of `[03, ff, ff]` is inferred from its position in the sequence and
+needs confirmation. It consistently follows the reset and precedes the point
+writes.
+
+The first profile's final commit was:
+
+```text
+5a010800d00505ffffd9       reset
+5a010800d10503ffffde       initialize custom-curve mode
+5a010900ca060008000ac6     channel 0, 08:00, 10%
+5a010900cb0600090014d8     channel 0, 09:00, 20%
+5a010900cc06000a001ed6     channel 0, 10:00, 30%
+5a010900cd06000b0028e0     channel 0, 11:00, 40%
+5a010900ce06000c0000cc     channel 0, 12:00, 0%
+5a010900cf0600070000c6     channel 0, 07:00, 0%
+```
+
+The points were not transmitted chronologically. A future implementation
+should not rely on write order to determine curve order.
+
+## App Curve Expansion
+
+The curve shown as `08:00 0%` to `11:00 40%` was expanded by the app into:
+
+| Time | Transmitted level |
+| --- | ---: |
+| `07:00` | `0%` |
+| `08:00` | `10%` |
+| `09:00` | `20%` |
+| `10:00` | `30%` |
+| `11:00` | `40%` |
+| `12:00` | `0%` |
+
+This does not exactly match the user-visible endpoints. The app may define a
+point as the end of the preceding interpolation interval, or this may be an app
+off-by-one-hour behavior. One capture is insufficient to distinguish those
+possibilities.
+
+While the curve editor was open, the app also sent live updates. For example,
+it repeatedly wrote the `09:00` point as its level was changed from `11%`
+through `20%`. These writes are editor updates, not additional schedule slots.
+The reset/setup sequence is a better boundary for identifying the final commit.
+
+## Constant-Level Profile
+
+The second profile starts with:
+
+```text
+5a010800d30505ffffda       reset
+5a010800d40503ffffdb       initialize custom-curve mode
+5a010900d2060008000ade     channel 0, 08:00, 10%
+```
+
+The capture ends after this point. A single point may mean that the last level
+persists until another point, but this is not confirmed. The traffic does not
+show how the app represents the remainder of the day or midnight rollover.
+
+## Notifications Seen During the Capture
+
+Only two application notifications were received. Both arrived during startup,
+before either new profile was written. ATT write responses followed the later
+commands, but there were no application-level acknowledgements or updated
+schedule snapshots after the saves.
+
+### Runtime/status notification
+
+```text
+5b170a00010a01ffffffff13888c
+```
+
+This is the already documented `0x5b / 0x0a` response. Firmware/protocol version
+is `0x17`, and bytes `6..7` decode as the currently interpreted runtime value
+`0x01ff = 511` minutes. Its XOR checksum validates.
+
+### Schedule snapshot notification
+
+```text
+5b17300001fe06113b0000000000000000000000000006113b
+0d0f000d2d64150f64152d0000000000000000000000000000
+```
+
+The schedule triples beginning at byte offset 25 decode as:
+
+| Bytes | Time | Level |
+| --- | --- | ---: |
+| `0d 0f 00` | `13:15` | `0%` |
+| `0d 2d 64` | `13:45` | `100%` |
+| `15 0f 64` | `21:15` | `100%` |
+| `15 2d 00` | `21:45` | `0%` |
+
+This is the schedule already stored when the app connected, not either newly
+created profile.
+
+The metadata contains `06 11 3b` twice. It plausibly means weekday `6` and
+local time `17:59`, which exactly matches Saturday at the capture time. This
+interpretation is strong but not yet proven by a capture made at another time.
+
+## Implementation Guidance
+
+A future custom-schedule implementation should:
+
+- represent this as a separate capability from the `0xa5 / 0x19` sunrise and
+  sunset schedule API;
+- add a four-parameter `0x5a / 0x06` command builder without removing support
+  for the older indexed three-parameter variant;
+- send the reset/setup sequence before committing all points;
+- validate channel, hour, minute, and percentage ranges;
+- preserve the caller's point order only for transmission, and treat schedule
+  semantics as time-sorted;
+- avoid claiming that a save succeeded based on a snapshot notification,
+  because this capture contains no post-save application acknowledgement; and
+- keep app-side interpolation separate from raw point transmission until its
+  endpoint behavior is understood.
+
+## Follow-up Captures Needed
+
+The highest-value follow-up captures are:
+
+1. A complete constant-level profile covering midnight.
+2. A two-point ramp with non-hour times and a level not divisible into even
+   steps, to determine the app's interpolation and rounding rules.
+3. Reading/reopening a newly saved profile, to capture its returned snapshot.
+4. Editing or deleting one point without replacing the entire profile.
+5. The same workflow on a multi-channel light, to confirm channel behavior and
+   whether points are written once per channel.
+6. A schedule involving weekdays, to determine whether custom curves support a
+   separate weekday command or are inherently daily.

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -189,6 +189,12 @@ selects every weekday, and `0x71` is the valid XOR checksum.
 Only one setting can be configured per day, so settings cannot conflict. There
 is a maximum of 7 settings.
 
+Single-channel A2 devices also have a distinct point-based custom-curve
+protocol using a four-parameter `0x5a / 0x06` command. It is not interchangeable
+with the `0xa5 / 0x19` schedule described above. See
+[A2 Custom Schedule Protocol](a2-custom-schedule-protocol.md) for the captured
+setup sequence, point encoding, and remaining unknowns.
+
 ## Weekday Bitmask
 
 Weekdays are encoded as a 7-bit mask:
@@ -290,7 +296,8 @@ snapshot as a status payload whose checksum/trailer is not yet confirmed.
 | Command ID | Mode | Parameters | Meaning |
 | ---: | ---: | --- | --- |
 | `0x5a` / `90` | `0x04` / `4` | `[1]` | Query LED runtime/status |
-| `0x5a` / `90` | `0x06` / `6` | `[color, time_index, level]` | Old 48-point auto curve update; `time_index` is `0..47` in 30-minute steps |
+| `0x5a` / `90` | `0x06` / `6` | `[color, time_index, level]` | Old 48-point auto curve variant; `time_index` is `0..47` in 30-minute steps |
+| `0x5a` / `90` | `0x06` / `6` | `[channel, hour, minute, level]` | A2 custom-curve point variant; see [the capture note](a2-custom-schedule-protocol.md) |
 | `0x5a` / `90` | `0x07` / `7` | `[color, brightness]` | Manual brightness |
 | `0x5a` / `90` | `0x09` / `9` | `[year - 2000, month, date_field, hour, minute, second]` | Set device time |
 | `0xa5` / `165` | `0x19` / `25` | 14 bytes | Add, update, or delete auto schedule |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -135,7 +135,7 @@ Other observed `0x5a / 0x05` first parameters:
 | `4` | Stop/exit demo in the old app |
 | `5` | Reset auto settings |
 | `6` | Temporary/new-firmware demo in the old app |
-| `11` / `0x0b` | First-connect/manual setup command, exact meaning unknown |
+| `11` / `0x0b` | First-connect/manual setup command; sent by the app before manual slider control on the WRGB VIVID III, likely switches to manual mode |
 | `18` | Enable auto mode |
 
 ## Auto Schedule Settings
@@ -300,7 +300,36 @@ snapshot as a status payload whose checksum/trailer is not yet confirmed.
 | `0x5a` / `90` | `0x06` / `6` | `[channel, hour, minute, level]` | A2 custom-curve point variant; see [the capture note](a2-custom-schedule-protocol.md) |
 | `0x5a` / `90` | `0x07` / `7` | `[color, brightness]` | Manual brightness |
 | `0x5a` / `90` | `0x09` / `9` | `[year - 2000, month, date_field, hour, minute, second]` | Set device time |
+| `0x5a` / `90` | `0x0f` / `15` | `[speed_percent]` | Fan speed, `0` to `100`; confirmed on WRGB VIVID III |
 | `0xa5` / `165` | `0x19` / `25` | 14 bytes | Add, update, or delete auto schedule |
+
+## Fan Status Notifications
+
+Fan-equipped devices such as the WRGB VIVID III (advertised name prefix
+`DYVVD3`) push a periodic status notification roughly every three seconds while
+connected. It uses the `0x5b` header with mode `0x0b`:
+
+```text
+5b 1b 10 00 01 0b 02 58 19 00 01 00 00 00 00 00 48 22
+```
+
+| Offset | Name | Observed meaning |
+| ---: | --- | --- |
+| `1` | Firmware/protocol version | `0x1b` / `27` on the captured VIVID III |
+| `6..7` | Fan RPM | Big-endian measured fan speed; `0x0258 = 600` rpm at 25%, about `1980` rpm at 100% |
+| `8` | Temperature | Whole degrees Celsius |
+| `16` | Uptime counter | Increments between periodic notifications |
+
+The trailing byte is not a valid XOR checksum for this mode, so parsers should
+treat bytes after offset `8` as opaque. Fan speed is set with the
+`0x5a / 0x0f` command listed above; measured RPM follows the set percentage.
+
+The VIVID III also sends a constant `0x5b` notification with mode `0x36` after
+each auth/status query. Its payload is static and its meaning is unknown; it
+can be ignored.
+
+Captured WRGB VIVID III channel order matches other true WRGB models: channel
+`0` red, `1` green, `2` blue, `3` white.
 
 ## Observed Command Families
 

--- a/src/chihiros_led_control/cli.py
+++ b/src/chihiros_led_control/cli.py
@@ -61,6 +61,12 @@ def set_brightness(device_address: str, brightness: Annotated[list[int], typer.A
 
 
 @app.command()
+def set_fan_speed(device_address: str, speed_percent: int) -> None:
+    """Set fan speed percentage on fan-equipped devices."""
+    _run_device_func(device_address, lambda dev: dev.set_fan_speed(speed_percent))
+
+
+@app.command()
 def add_setting(
     device_address: str,
     sunrise: Annotated[datetime, typer.Argument(formats=["%H:%M"])],

--- a/src/chihiros_led_control/client.py
+++ b/src/chihiros_led_control/client.py
@@ -27,6 +27,7 @@ from .const import UART_RX_CHAR_UUID, UART_TX_CHAR_UUID
 from .exceptions import CharacteristicMissingError
 from .models import FALLBACK, DeviceModel
 from .protocol import (
+    FanStatusNotification,
     ParsedNotification,
     RuntimeNotification,
     ScheduleSnapshotNotification,
@@ -69,6 +70,7 @@ class ChihirosDevice:
         self._msg_id = next_message_id()
         self._notification_callbacks: set[NotificationCallback] = set()
         self.last_runtime_notification: RuntimeNotification | None = None
+        self.last_fan_status_notification: FanStatusNotification | None = None
         self.last_schedule_snapshot_notification: ScheduleSnapshotNotification | None = None
         self.loop = asyncio.get_running_loop()
 
@@ -221,6 +223,13 @@ class ChihirosDevice:
         cmd = commands.create_query_status_command(self.get_next_msg_id())
         await self._send_command(cmd, 3, notification_wait=STATUS_NOTIFICATION_WAIT)
 
+    async def set_fan_speed(self, speed_percent: int) -> None:
+        """Set the fan speed percentage on fan-equipped models."""
+        if not self.model.has_fan:
+            raise ValueError(f"Model does not support fan control: {self.model.name}")
+        cmd = commands.create_set_fan_speed_command(self.get_next_msg_id(), speed_percent)
+        await self._send_command(cmd, 3)
+
     async def add_setting(
         self,
         sunrise: datetime,
@@ -345,6 +354,17 @@ class ChihirosDevice:
                 self.name,
                 parsed.firmware_version,
                 parsed.runtime_minutes,
+            )
+            self._notify_callbacks(parsed)
+            return
+        if isinstance(parsed, FanStatusNotification):
+            self.last_fan_status_notification = parsed
+            self._logger.debug(
+                "%s: Fan status notification received; firmware=%s fan_rpm=%s temperature_celsius=%s",
+                self.name,
+                parsed.firmware_version,
+                parsed.fan_rpm,
+                parsed.temperature_celsius,
             )
             self._notify_callbacks(parsed)
             return

--- a/src/chihiros_led_control/commands.py
+++ b/src/chihiros_led_control/commands.py
@@ -116,3 +116,10 @@ def create_reset_auto_settings_command(msg_id: tuple[int, int]) -> bytearray:
 def create_switch_to_auto_mode_command(msg_id: tuple[int, int]) -> bytearray:
     """Create a switch to auto mode command."""
     return create_command_encoding(90, 5, msg_id, [18, 255, 255])
+
+
+def create_set_fan_speed_command(msg_id: tuple[int, int], speed_percent: int) -> bytearray:
+    """Create a fan speed command for fan-equipped LED devices such as the WRGB VIVID III."""
+    if speed_percent < 0 or speed_percent > 100:
+        raise ValueError("Fan speed must be between 0 and 100 percent")
+    return create_command_encoding(90, 15, msg_id, [speed_percent])

--- a/src/chihiros_led_control/models.py
+++ b/src/chihiros_led_control/models.py
@@ -16,6 +16,7 @@ class DeviceModel:
     color_channels: Mapping[str, int]
     needs_device_type: bool = False
     fallback: bool = False
+    has_fan: bool = False
 
 
 WHITE_CHANNELS = MappingProxyType({"white": 0})
@@ -51,6 +52,7 @@ SUPPORTED_MODELS: tuple[DeviceModel, ...] = (
         ("DYSILN", "DYSL30", "DYSL45", "DYSL60", "DYSL90", "DYSL120", "DYSL12"),
         RGB_CHANNELS,
     ),
+    DeviceModel("WRGB VIVID III", ("DYVVD3",), WRGB_CHANNELS, has_fan=True),
     DeviceModel("C II", ("DYNC2N",), WHITE_CHANNELS),
     DeviceModel("C II RGB", ("DYNCRGP", "DYNCRGB"), RGB_CHANNELS),
     DeviceModel(

--- a/src/chihiros_led_control/protocol.py
+++ b/src/chihiros_led_control/protocol.py
@@ -21,6 +21,16 @@ class RuntimeNotification:
 
 
 @dataclass(frozen=True)
+class FanStatusNotification:
+    """Parsed fan-equipped device status notification."""
+
+    firmware_version: int
+    fan_rpm: int
+    temperature_celsius: int
+    raw: bytes = field(default=b"", compare=False)
+
+
+@dataclass(frozen=True)
 class SchedulePoint:
     """Parsed auto schedule point."""
 
@@ -38,7 +48,7 @@ class ScheduleSnapshotNotification:
     raw: bytes = field(default=b"", compare=False)
 
 
-ParsedNotification = RuntimeNotification | ScheduleSnapshotNotification
+ParsedNotification = RuntimeNotification | FanStatusNotification | ScheduleSnapshotNotification
 
 
 def next_message_id(current_msg_id: tuple[int, int] = (0, 0)) -> tuple[int, int]:
@@ -133,6 +143,11 @@ def parse_notification(
     if mode == 0x0A and len(data) >= 8:
         runtime_minutes = (data[6] << 8) | data[7]
         return RuntimeNotification(firmware_version, runtime_minutes, bytes(data))
+
+    if mode == 0x0B and len(data) >= 9:
+        fan_rpm = (data[6] << 8) | data[7]
+        temperature_celsius = data[8]
+        return FanStatusNotification(firmware_version, fan_rpm, temperature_celsius, bytes(data))
 
     if mode == 0xFE:
         if color_channels is None:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -13,7 +13,12 @@ from bleak_retry_connector import BleakError
 from chihiros_led_control.client import ChihirosDevice, ChihirosDosingPump
 from chihiros_led_control.exceptions import CharacteristicMissingError
 from chihiros_led_control.models import RGB_CHANNELS, WHITE_CHANNELS, WRGB_CHANNELS, DeviceModel
-from chihiros_led_control.protocol import RuntimeNotification, ScheduleSnapshotNotification, calculate_checksum
+from chihiros_led_control.protocol import (
+    FanStatusNotification,
+    RuntimeNotification,
+    ScheduleSnapshotNotification,
+    calculate_checksum,
+)
 
 
 class FakeBLEDevice:
@@ -371,6 +376,58 @@ def test_notification_handler_stores_and_publishes_schedule_snapshot() -> None:
     device = asyncio.run(run())
     assert isinstance(device.last_schedule_snapshot_notification, ScheduleSnapshotNotification)
     assert received == [device.last_schedule_snapshot_notification]
+
+
+def test_notification_handler_stores_and_publishes_fan_status() -> None:
+    """Parsed fan status notifications are stored and sent to subscribers."""
+    received: list[FanStatusNotification] = []
+    frame = bytearray.fromhex("5b 1b 10 00 01 0b 02 58 19 00 01 00 00 00 00 00 48 22")
+
+    async def run() -> ChihirosDevice:
+        device = ChihirosDevice(FakeBLEDevice(), DeviceModel("Test", (), WRGB_CHANNELS, has_fan=True))  # type: ignore[arg-type]
+        device.add_notification_callback(received.append)
+        device._notification_handler(None, frame)  # type: ignore[arg-type]
+        return device
+
+    device = asyncio.run(run())
+    assert device.last_fan_status_notification == FanStatusNotification(
+        firmware_version=27,
+        fan_rpm=600,
+        temperature_celsius=25,
+        raw=bytes(frame),
+    )
+    assert received == [device.last_fan_status_notification]
+
+
+def test_set_fan_speed_sends_captured_command_shape() -> None:
+    """Fan speed commands use mode 0x0F with the speed percentage parameter."""
+    sent_commands: list[bytes] = []
+
+    async def run() -> None:
+        device = ChihirosDevice(FakeBLEDevice(), DeviceModel("Test", (), WRGB_CHANNELS, has_fan=True))  # type: ignore[arg-type]
+
+        async def capture_command(command: list[bytes] | bytes | bytearray, retry: int | None = None) -> None:
+            del retry
+            sent_commands.append(bytes(command))
+
+        device._send_command = capture_command  # type: ignore[method-assign]
+
+        await device.set_fan_speed(100)
+
+    asyncio.run(run())
+
+    assert sent_commands[0][5:7] == bytes([15, 100])
+
+
+def test_set_fan_speed_rejects_models_without_fan() -> None:
+    """Fan control is limited to fan-equipped models."""
+
+    async def run() -> None:
+        device = ChihirosDevice(FakeBLEDevice(), DeviceModel("Test", (), WHITE_CHANNELS))  # type: ignore[arg-type]
+        with pytest.raises(ValueError, match="fan"):
+            await device.set_fan_speed(50)
+
+    asyncio.run(run())
 
 
 def test_set_brightness_sends_all_true_wrgb_channels() -> None:

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -48,6 +48,15 @@ def test_detect_model_matches_dosing_pump_prefix() -> None:
     assert detect_model("DYDOSE1234567890").name == "Dosing Pump"
 
 
+def test_detect_model_matches_wrgb_vivid_iii_prefix() -> None:
+    """Model detection matches WRGB VIVID III advertisements and enables fan support."""
+    model = detect_model("DYVVD3CDA1ECD07A4D")
+
+    assert model.name == "WRGB VIVID III"
+    assert dict(model.color_channels) == {"white": 3, "red": 0, "green": 1, "blue": 2}
+    assert model.has_fan is True
+
+
 def test_unknown_model_needs_device_type() -> None:
     """Unknown models use fallback metadata and need a type."""
     assert detect_model("UNKNOWN").fallback is True

--- a/tests/test_home_assistant_unit.py
+++ b/tests/test_home_assistant_unit.py
@@ -38,7 +38,11 @@ from custom_components.chihiros.discovery import ChihirosDiscovery, discovery_ti
 from custom_components.chihiros.dosing import PUMP_COUNT, _coerce_total, is_dosing_capable, normalize_pump_count
 from custom_components.chihiros.fake import FAKE_DEVICES, create_fake_device, is_fake_address
 from custom_components.chihiros.vendor.chihiros_led_control.models import DOSING_PUMP
-from custom_components.chihiros.vendor.chihiros_led_control.protocol import RuntimeNotification, SchedulePoint
+from custom_components.chihiros.vendor.chihiros_led_control.protocol import (
+    FanStatusNotification,
+    RuntimeNotification,
+    SchedulePoint,
+)
 
 pytestmark = pytest.mark.unit
 
@@ -232,6 +236,17 @@ def test_schedule_and_notification_debug_conversion() -> None:
         "parsed_type": "runtime",
     }
 
+    fan_notification = FanStatusNotification(
+        27, 600, 25, bytes.fromhex("5b 1b 10 00 01 0b 02 58 19 00 01 00 00 00 00 00 48 22")
+    )
+    assert _notification_to_debug_dict(fan_notification, "fan_status") == {
+        "firmware_version": 27,
+        "frame": "5b 1b 10 00 01 0b 02 58 19 00 01 00 00 00 00 00 48 22",
+        "payload": "02 58 19 00 01 00 00 00 00 00 48 22",
+        "mode": "0x0b",
+        "parsed_type": "fan_status",
+    }
+
 
 @pytest.mark.asyncio
 async def test_fake_device_supports_all_brightness_shapes_and_callbacks() -> None:
@@ -252,6 +267,34 @@ async def test_fake_device_supports_all_brightness_shapes_and_callbacks() -> Non
     assert device.model_name == FAKE_DEVICES[0].model.name
     assert device.colors == dict(FAKE_DEVICES[0].model.color_channels)
     assert is_fake_address(device.address)
+
+
+@pytest.mark.asyncio
+async def test_fake_fan_device_publishes_fan_status() -> None:
+    """The fan-equipped fake device behaves like the fan client surface."""
+    fan_device_info = next(device for device in FAKE_DEVICES if device.model.has_fan)
+    device = create_fake_device(fan_device_info.address)
+    notifications: list[object] = []
+    device.add_notification_callback(notifications.append)
+
+    await device.set_fan_speed(50)
+
+    assert device.last_fan_status_notification == FanStatusNotification(
+        firmware_version=27, fan_rpm=1000, temperature_celsius=25
+    )
+    assert notifications == [device.last_fan_status_notification]
+
+    with pytest.raises(ValueError, match="between 0 and 100"):
+        await device.set_fan_speed(101)
+
+
+@pytest.mark.asyncio
+async def test_fake_device_without_fan_rejects_fan_speed() -> None:
+    """Fake devices without a fan reject fan speed commands."""
+    device = create_fake_device(FAKE_DEVICES[0].address)
+
+    with pytest.raises(ValueError, match="fan control"):
+        await device.set_fan_speed(50)
 
 
 def test_discovery_helpers_for_fake_device() -> None:

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -7,6 +7,7 @@ import datetime
 from chihiros_led_control import commands
 from chihiros_led_control.models import RGB_CHANNELS, WHITE_CHANNELS, WRGB_CHANNELS
 from chihiros_led_control.protocol import (
+    FanStatusNotification,
     RuntimeNotification,
     SchedulePoint,
     ScheduleSnapshotNotification,
@@ -145,6 +146,23 @@ def test_query_status_command_encoding() -> None:
     assert commands.create_query_status_command((0, 1)) == commands.create_base_auth_command((0, 1))
 
 
+def test_set_fan_speed_command_matches_captured_frames() -> None:
+    """Fan speed commands match frames captured from a WRGB VIVID III."""
+    assert commands.create_set_fan_speed_command((0, 0xC7), 100) == bytearray.fromhex("5A 01 06 00 C7 0F 64 AB")
+    assert commands.create_set_fan_speed_command((0, 0xC5), 53) == bytearray.fromhex("5A 01 06 00 C5 0F 35 F8")
+    assert commands.create_set_fan_speed_command((0, 0xCB), 0) == bytearray.fromhex("5A 01 06 00 CB 0F 00 C3")
+
+
+def test_set_fan_speed_command_validates_range() -> None:
+    """Fan speed commands reject out-of-range percentages."""
+    for speed in (-1, 101):
+        try:
+            commands.create_set_fan_speed_command((0, 1), speed)
+        except ValueError:
+            continue
+        raise AssertionError(f"Expected ValueError for fan speed {speed}")
+
+
 def test_auto_setting_command_accepts_four_channel_brightness() -> None:
     """Auto schedule commands can encode true WRGB brightness values."""
     command = commands.create_add_auto_setting_command(
@@ -203,6 +221,27 @@ def test_parse_notification_rejects_short_or_unknown_frames() -> None:
     """Inbound frames still require the Chihiros header and mode fields."""
     assert parse_notification(bytes([0x5B, 0, 2, 0, 0, 0, 0])) is None
     assert parse_notification(bytes([0x00, 0, 3, 0, 0, 0, 0, 0])) is None
+
+
+def test_parse_fan_status_notification() -> None:
+    """Fan status notifications expose firmware, fan RPM, and temperature."""
+    frame = bytearray.fromhex("5b 1b 10 00 01 0b 02 58 19 00 01 00 00 00 00 00 48 22")
+    notification = parse_notification(frame)
+
+    assert notification == FanStatusNotification(
+        firmware_version=27, fan_rpm=600, temperature_celsius=25, raw=bytes(frame)
+    )
+
+
+def test_parse_fan_status_notification_tolerates_trailing_counter() -> None:
+    """Fan status notifications parse regardless of the trailing uptime counter byte."""
+    running = bytearray.fromhex("5b 1b 10 00 01 0b 07 bc 19 00 01 00 00 00 00 00 57 22")
+    idle = bytearray.fromhex("5b 1b 10 00 01 0b 00 1e 18 00 01 00 00 00 00 00 00 22")
+
+    assert parse_notification(running) == FanStatusNotification(
+        firmware_version=27, fan_rpm=1980, temperature_celsius=25
+    )
+    assert parse_notification(idle) == FanStatusNotification(firmware_version=27, fan_rpm=30, temperature_celsius=24)
 
 
 def test_parse_schedule_snapshot_notification_requires_channel_context() -> None:


### PR DESCRIPTION
Closes #103.

## Summary

Adds support for the **Chihiros WRGB VIVID III** (advertised prefix `DYVVD3`), verified against a btsnoop capture of the official My Chihiros app controlling the device (lamp on/off, per-channel brightness, fan control).

### Protocol verification (from capture)

The VIVID III speaks the existing protocol unchanged — all 74 captured commands validate byte-for-byte against `create_command_encoding()`:

- Same Nordic UART service/characteristics (`6e400001/2/3`)
- Same connection prelude (auth `5a/04 [01]`, double RTC sync `5a/09` with ISO weekday)
- Same brightness command `5a/07 [channel, level]`; channel order matches true WRGB models: `0` red, `1` green, `2` blue, `3` white
- Runtime/status query and `0x5b / 0x0a` runtime notification (firmware 27)

New findings decoded from the capture:

- **Fan control**: `5a / 0x0f [speed_percent]` (0–100)
- **Fan status notification** `0x5b / 0x0b`, pushed every ~3 s: fan RPM (u16 BE), temperature °C
- Unknown constant notification mode `0x36` after auth (ignored)

### Changes

**Library**
- `models.py`: `WRGB VIVID III` (`DYVVD3`, WRGB channels) + new `has_fan` model flag
- `commands.py`: `create_set_fan_speed_command()`
- `protocol.py`: `FanStatusNotification` (fan RPM, temperature)
- `client.py`: `set_fan_speed()`, fan status notification handling
- `cli.py`: `chihirosctl set-fan-speed`

**Home Assistant integration**
- New `fan` platform: speed 0–100 %, state restore, measured RPM attribute
- New sensors: fan RPM and temperature (created only for fan-equipped models)
- Coordinator routes fan status notifications; fake device + runtime protocol extended
- Vendored library refreshed (`scripts/sync_vendor.py`)

**Docs**: fan command + fan status notification layout in `docs/protocol.md`; README device list.

Also includes a separate docs commit covering the previously captured A2 custom-curve protocol.

### Validation

- Library tests: 85 passed (`--group test`, as CI)
- Home Assistant tests: 37 passed, coverage 76.8 % (gate: 75 %)
- `pre-commit run --all-files`: all hooks pass (ruff check/format, vendor sync check, …)

### Not yet verified

Auto-schedule commands (`0xa5 / 0x19`) were not exercised in the capture; schedule support is assumed from protocol compatibility but untested on this model.
