### PR TITLE
feat: add unified RGB/RGBW light entity for single-packet channel control

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -57,6 +57,11 @@ jobs:
           uv --cache-dir .uv-cache run --frozen --group test pytest
           --ignore=tests/test_home_assistant_integration.py
           --ignore=tests/test_home_assistant_unit.py
+          --ignore=tests/test_light_rgb.py
+          --ignore=tests/test_fan.py
+          --ignore=tests/test_coordinator.py
+          --ignore=tests/test_dosing.py
+          --ignore=tests/test_sensor.py
           --cov=chihiros_led_control
           --cov-report=term-missing
           --cov-report=xml:coverage-library.xml
@@ -89,6 +94,11 @@ jobs:
           uv --cache-dir .uv-cache run --frozen --group ha-test pytest
           tests/test_home_assistant_unit.py
           tests/test_home_assistant_integration.py
+          tests/test_light_rgb.py
+          tests/test_fan.py
+          tests/test_coordinator.py
+          tests/test_dosing.py
+          tests/test_sensor.py
           --cov=custom_components/chihiros
           --cov-report=term-missing
           --cov-report=xml:coverage-home-assistant.xml

--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -55,13 +55,7 @@ jobs:
       - name: Run library tests with coverage
         run: >-
           uv --cache-dir .uv-cache run --frozen --group test pytest
-          --ignore=tests/test_home_assistant_integration.py
-          --ignore=tests/test_home_assistant_unit.py
-          --ignore=tests/test_light_rgb.py
-          --ignore=tests/test_fan.py
-          --ignore=tests/test_coordinator.py
-          --ignore=tests/test_dosing.py
-          --ignore=tests/test_sensor.py
+          -m "not integration and not unit"
           --cov=chihiros_led_control
           --cov-report=term-missing
           --cov-report=xml:coverage-library.xml
@@ -92,13 +86,7 @@ jobs:
       - name: Run Home Assistant tests with coverage
         run: >-
           uv --cache-dir .uv-cache run --frozen --group ha-test pytest
-          tests/test_home_assistant_unit.py
-          tests/test_home_assistant_integration.py
-          tests/test_light_rgb.py
-          tests/test_fan.py
-          tests/test_coordinator.py
-          tests/test_dosing.py
-          tests/test_sensor.py
+          -m "integration or unit"
           --cov=custom_components/chihiros
           --cov-report=term-missing
           --cov-report=xml:coverage-home-assistant.xml

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains a python **CLI** script as well as a **Home Assistant i
 - Chihiros Z Light TINY
 - Chihiros Commander 1
 - Chihiros Commander 4
-- Chihiros dosing pump (`DYDOSE*`) with first Home Assistant support for manual dosing and daily dose totals
+- Chihiros dosing pump (`DYDOSE*`) with first Home Assistant support for manual dosing, daily dose totals, and lifetime pump cycle/ml counters
 - other LED models might work as well but are not tested
 
 
@@ -109,7 +109,15 @@ written, so `set_schedule` accepts at most one period per weekday. After writing
 a schedule, enable the `Auto Mode` switch to run it.
 
 Dosing pumps expose one manual dose button, one dose-volume number control, and
-one locally tracked daily total sensor per pump channel. The first setup asks
+the following locally tracked sensors per pump channel:
+
+- `dosed today` (volume in mL, reset at local midnight)
+- `total ml` (cumulative lifetime volume, `total_increasing`)
+- `total cycles` (cumulative lifetime dose count, `total_increasing`)
+
+The lifetime `total ml` and `total cycles` sensors are `total_increasing`, so they
+can be fed directly into the Home Assistant `utility_meter` to derive daily,
+weekly, monthly, or yearly consumption sensors. The first setup asks
 whether the pump has two or four channels. Manual doses can also be triggered
 from automations with `chihiros.dose_ml`:
 

--- a/custom_components/chihiros/dosing.py
+++ b/custom_components/chihiros/dosing.py
@@ -33,6 +33,8 @@ class DosingDailyTotals:
     _store: Store[dict[str, Any]] = field(init=False)
     _date: str = field(init=False)
     _totals: list[float] = field(init=False)
+    _lifetime_ml: list[float] = field(init=False)
+    _lifetime_cycles: list[int] = field(init=False)
     _unsub_midnight_reset: Any = None
 
     def __post_init__(self) -> None:
@@ -41,6 +43,8 @@ class DosingDailyTotals:
         self.pump_count = normalize_pump_count(self.pump_count)
         self._date = self._today()
         self._totals = [0.0] * self.pump_count
+        self._lifetime_ml = [0.0] * self.pump_count
+        self._lifetime_cycles = [0] * self.pump_count
 
     @property
     def address_signal(self) -> str:
@@ -51,14 +55,13 @@ class DosingDailyTotals:
         """Load today's totals from Home Assistant storage."""
         stored = await self._store.async_load()
         if isinstance(stored, dict):
+            self._lifetime_ml = _coerce_total_list(stored.get("lifetime_ml"), self.pump_count)
+            self._lifetime_cycles = _coerce_cycles_list(stored.get("lifetime_cycles"), self.pump_count)
             stored_date = stored.get("date")
             stored_totals = stored.get("totals_ml")
             if stored_date == self._today() and isinstance(stored_totals, list):
                 self._date = stored_date
-                self._totals = [
-                    _coerce_total(stored_totals[index] if index < len(stored_totals) else 0.0)
-                    for index in range(self.pump_count)
-                ]
+                self._totals = _coerce_total_list(stored_totals, self.pump_count)
             else:
                 await self.async_reset()
         self._schedule_midnight_reset()
@@ -69,11 +72,23 @@ class DosingDailyTotals:
         self._validate_pump_idx(pump_idx)
         return self._totals[pump_idx]
 
+    def lifetime_ml(self, pump_idx: int) -> float:
+        """Return the lifetime dosed volume for a zero-based pump index."""
+        self._validate_pump_idx(pump_idx)
+        return self._lifetime_ml[pump_idx]
+
+    def lifetime_cycles(self, pump_idx: int) -> int:
+        """Return the lifetime dose count for a zero-based pump index."""
+        self._validate_pump_idx(pump_idx)
+        return self._lifetime_cycles[pump_idx]
+
     async def async_add_dose(self, pump_idx: int, volume_ml: float) -> None:
         """Add a successful manual dose to today's local total."""
         self._ensure_today_sync()
         self._validate_pump_idx(pump_idx)
         self._totals[pump_idx] = round(self._totals[pump_idx] + volume_ml, 1)
+        self._lifetime_ml[pump_idx] = round(self._lifetime_ml[pump_idx] + volume_ml, 1)
+        self._lifetime_cycles[pump_idx] += 1
         await self.async_save()
         async_dispatcher_send(self.hass, self.address_signal)
 
@@ -86,7 +101,14 @@ class DosingDailyTotals:
 
     async def async_save(self) -> None:
         """Persist totals to Home Assistant storage."""
-        await self._store.async_save({"date": self._date, "totals_ml": self._totals})
+        await self._store.async_save(
+            {
+                "date": self._date,
+                "totals_ml": self._totals,
+                "lifetime_ml": self._lifetime_ml,
+                "lifetime_cycles": self._lifetime_cycles,
+            }
+        )
 
     def async_close(self) -> None:
         """Cancel scheduled callbacks."""
@@ -141,3 +163,26 @@ def _coerce_total(value: object) -> float:
         return round(float(value), 1)
     except (TypeError, ValueError):
         return 0.0
+
+
+def _coerce_total_list(values: object, pump_count: int) -> list[float]:
+    """Coerce a stored list of per-pump totals into a fixed-length float list."""
+    if not isinstance(values, list):
+        return [0.0] * pump_count
+    return [_coerce_total(values[index]) if index < len(values) else 0.0 for index in range(pump_count)]
+
+
+def _coerce_cycles_list(values: object, pump_count: int) -> list[int]:
+    """Coerce a stored list of per-pump cycle counts into a fixed-length int list."""
+    if not isinstance(values, list):
+        return [0] * pump_count
+    coerced: list[int] = []
+    for index in range(pump_count):
+        if index >= len(values):
+            coerced.append(0)
+            continue
+        try:
+            coerced.append(int(round(float(values[index]))))
+        except (TypeError, ValueError):
+            coerced.append(0)
+    return coerced

--- a/custom_components/chihiros/light.py
+++ b/custom_components/chihiros/light.py
@@ -40,20 +40,25 @@ async def async_setup_entry(
     """Set up the light platform for LEDBLE."""
     chihiros_data: ChihirosData = hass.data[DOMAIN][entry.entry_id]
     _LOGGER.debug("Setup chihiros entry: %s", chihiros_data.device.address)
-    for color in chihiros_data.device.colors:
-        _LOGGER.debug("Setup chihiros light entity: %s - %s", chihiros_data.device.address, color)
-        async_add_entities(
-            [
-                ChihirosLightEntity(
-                    chihiros_data.coordinator,
-                    chihiros_data.device,
-                    color=color,
-                )
-            ]
-        )
-
     channels = chihiros_data.device.colors
     has_rgb = "red" in channels and "green" in channels and "blue" in channels
+    # RGB/WRGB devices expose a single unified entity that writes every colour
+    # channel in one BLE transaction, so per-channel entities are not created for
+    # them (per-channel writes collide on the wire). White-only and partial
+    # colour models still get one brightness entity per channel.
+    if not has_rgb:
+        for color in channels:
+            _LOGGER.debug("Setup chihiros light entity: %s - %s", chihiros_data.device.address, color)
+            async_add_entities(
+                [
+                    ChihirosLightEntity(
+                        chihiros_data.coordinator,
+                        chihiros_data.device,
+                        color=color,
+                    )
+                ]
+            )
+
     if has_rgb:
         _LOGGER.debug("Setup chihiros RGB light entity: %s", chihiros_data.device.address)
         async_add_entities(
@@ -247,13 +252,11 @@ class ChihirosRGBLightEntity(
             self._attr_rgb_color = (r, g, b)
             await self._set_rgb_brightness((r, g, b, w), self._attr_brightness)
         elif ATTR_RGB_COLOR in kwargs:
+            # Home Assistant converts rgb_color -> rgbw_color (white=0) for
+            # RGBW entities, so this branch is only reached on pure RGB models.
             r, g, b = (int(c) for c in kwargs[ATTR_RGB_COLOR])
             self._attr_rgb_color = (r, g, b)
-            if self._has_white:
-                # Only update RGB channels; leave white unchanged.
-                await self._set_rgb_brightness((r, g, b), self._attr_brightness)
-            else:
-                await self._set_rgb_brightness((r, g, b), self._attr_brightness)
+            await self._set_rgb_brightness((r, g, b), self._attr_brightness)
         else:
             if self._has_white:
                 color = self._attr_rgbw_color or (255, 255, 255, 255)

--- a/custom_components/chihiros/light.py
+++ b/custom_components/chihiros/light.py
@@ -9,7 +9,13 @@ from typing import Any
 from homeassistant.components.bluetooth.passive_update_coordinator import (
     PassiveBluetoothCoordinatorEntity,
 )
-from homeassistant.components.light import ATTR_BRIGHTNESS, ColorMode, LightEntity
+from homeassistant.components.light import (
+    ATTR_BRIGHTNESS,
+    ATTR_RGB_COLOR,
+    ATTR_RGBW_COLOR,
+    ColorMode,
+    LightEntity,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
@@ -42,6 +48,19 @@ async def async_setup_entry(
                     chihiros_data.coordinator,
                     chihiros_data.device,
                     color=color,
+                )
+            ]
+        )
+
+    channels = chihiros_data.device.colors
+    has_rgb = "red" in channels and "green" in channels and "blue" in channels
+    if has_rgb:
+        _LOGGER.debug("Setup chihiros RGB light entity: %s", chihiros_data.device.address)
+        async_add_entities(
+            [
+                ChihirosRGBLightEntity(
+                    chihiros_data.coordinator,
+                    chihiros_data.device,
                 )
             ]
         )
@@ -131,6 +150,170 @@ class ChihirosLightEntity(
         """Set brightness and keep Home Assistant availability in sync."""
         try:
             await self._device.set_brightness({self._color: brightness})
+        except Exception as ex:
+            self._attr_available = False
+            self.schedule_update_ha_state()
+            raise HomeAssistantError(f"Failed to set brightness for {self.name}") from ex
+        self._attr_available = True
+        self.coordinator.async_set_auto_mode(False)
+
+
+class ChihirosRGBLightEntity(
+    PassiveBluetoothCoordinatorEntity[ChihirosDataUpdateCoordinator],
+    LightEntity,
+    RestoreEntity,
+):
+    """Unified RGB/RGBW light entity for a Chihiros device.
+
+    Exposes a single entity that sets all color channels simultaneously
+    in one BLE transaction, avoiding packet collisions that occur when
+    per-channel entities are triggered in parallel.
+    """
+
+    _attr_assumed_state = True
+    _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: ChihirosDataUpdateCoordinator,
+        chihiros_device: ChihirosClient,
+    ) -> None:
+        """Initialise the entity."""
+        super().__init__(coordinator)
+        self._device = chihiros_device
+        self._address = coordinator.address
+        self._has_white = "white" in self._device.colors
+        self._color_mode = ColorMode.RGBW if self._has_white else ColorMode.RGB
+        self._attr_supported_color_modes = {self._color_mode}
+        self._attr_color_mode = self._color_mode
+
+        self._attr_name = chihiros_entity_name(self._device, "RGBW" if self._has_white else "RGB")
+        self._attr_unique_id = chihiros_unique_id(self._address, "rgbw" if self._has_white else "rgb")
+        self._attr_device_info = chihiros_device_info(self._device, self._address)
+
+        self._attr_rgb_color: tuple[int, ...] = (255, 255, 255)
+        if self._has_white:
+            self._attr_rgbw_color: tuple[int, ...] | None = (255, 255, 255, 255)
+        else:
+            self._attr_rgbw_color = None
+
+    async def async_added_to_hass(self) -> None:
+        """Handle entity about to be added to hass event."""
+        _LOGGER.debug("Called async_added_to_hass: %s", self.name)
+        await super().async_added_to_hass()
+        if last_state := await self.async_get_last_state():
+            self._attr_is_on = last_state.state == STATE_ON
+            self._attr_brightness = last_state.attributes.get("brightness")
+            if rgb := last_state.attributes.get("rgb_color"):
+                self._attr_rgb_color = tuple(rgb)
+            if rgbw := last_state.attributes.get("rgbw_color"):
+                self._attr_rgbw_color = tuple(rgbw)
+
+    @property
+    def available(self) -> bool:
+        """Return whether the light is available."""
+        if self.coordinator.always_available:
+            return True
+        return super().available
+
+    @property
+    def brightness(self) -> int | None:
+        """Return the brightness property."""
+        return self._attr_brightness
+
+    @property
+    def rgb_color(self) -> tuple[int, ...] | None:
+        """Return the rgb color."""
+        return self._attr_rgb_color
+
+    @property
+    def rgbw_color(self) -> tuple[int, ...] | None:
+        """Return the rgbw color."""
+        return self._attr_rgbw_color
+
+    @property
+    def color_mode(self) -> str | None:
+        """Return the color mode of the light."""
+        return self._attr_color_mode
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Instruct the light to turn on."""
+        master_brightness = kwargs.get(ATTR_BRIGHTNESS, self._attr_brightness or 255)
+        self._attr_brightness = int(master_brightness)
+
+        if ATTR_RGBW_COLOR in kwargs and self._has_white:
+            r, g, b, w = (int(c) for c in kwargs[ATTR_RGBW_COLOR])
+            self._attr_rgbw_color = (r, g, b, w)
+            self._attr_rgb_color = (r, g, b)
+            await self._set_rgb_brightness((r, g, b, w), self._attr_brightness)
+        elif ATTR_RGB_COLOR in kwargs:
+            r, g, b = (int(c) for c in kwargs[ATTR_RGB_COLOR])
+            self._attr_rgb_color = (r, g, b)
+            if self._has_white:
+                # Only update RGB channels; leave white unchanged.
+                await self._set_rgb_brightness((r, g, b), self._attr_brightness)
+            else:
+                await self._set_rgb_brightness((r, g, b), self._attr_brightness)
+        else:
+            if self._has_white:
+                color = self._attr_rgbw_color or (255, 255, 255, 255)
+                await self._set_rgb_brightness(color, self._attr_brightness)
+            else:
+                color = self._attr_rgb_color or (255, 255, 255)
+                await self._set_rgb_brightness(color, self._attr_brightness)
+
+        self._attr_is_on = True
+        self.schedule_update_ha_state()
+        _LOGGER.debug("Turned on: %s", self.name)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Instruct the light to turn off."""
+        _LOGGER.debug("Turning off: %s", self.name)
+        channels = dict.fromkeys(self._device.colors, 0)
+        try:
+            await self._device.set_brightness(channels)
+        except Exception as ex:
+            self._attr_available = False
+            self.schedule_update_ha_state()
+            raise HomeAssistantError(f"Failed to turn off {self.name}") from ex
+        self._attr_available = True
+        self._attr_is_on = False
+        self._attr_brightness = 0
+        self.coordinator.async_set_auto_mode(False)
+        self.schedule_update_ha_state()
+        _LOGGER.debug("Turned off: %s", self.name)
+
+    @staticmethod
+    def _scale_channel(value: int, master_brightness: int) -> int:
+        """Scale a 0-255 colour value by master brightness to a 0-100 device level."""
+        return max(0, math.ceil((value * master_brightness) / 255 / 255 * 100))
+
+    async def _set_rgb_brightness(
+        self,
+        color: tuple[int, ...],
+        master_brightness: int,
+    ) -> None:
+        """Send all colour channels to the device in one BLE transaction."""
+        channels: dict[str, int] = {}
+        if len(color) == 4:
+            r, g, b, w = color
+            channels = {
+                "red": self._scale_channel(r, master_brightness),
+                "green": self._scale_channel(g, master_brightness),
+                "blue": self._scale_channel(b, master_brightness),
+                "white": self._scale_channel(w, master_brightness),
+            }
+        else:
+            r, g, b = color
+            channels = {
+                "red": self._scale_channel(r, master_brightness),
+                "green": self._scale_channel(g, master_brightness),
+                "blue": self._scale_channel(b, master_brightness),
+            }
+
+        _LOGGER.debug("Setting RGB brightness on %s: %s", self.name, channels)
+        try:
+            await self._device.set_brightness(channels)
         except Exception as ex:
             self._attr_available = False
             self.schedule_update_ha_state()

--- a/custom_components/chihiros/manifest.json
+++ b/custom_components/chihiros/manifest.json
@@ -96,5 +96,5 @@
   "iot_class": "assumed_state",
   "issue_tracker": "https://github.com/TheMicDiet/chihiros-led-control/issues",
   "requirements": [],
-  "version": "0.12.0"
+  "version": "0.13.0"
 }

--- a/custom_components/chihiros/sensor.py
+++ b/custom_components/chihiros/sensor.py
@@ -82,15 +82,19 @@ async def async_setup_entry(
     """Set up notification sensors for Chihiros LED Control."""
     chihiros_data: ChihirosData = hass.data[DOMAIN][entry.entry_id]
     if chihiros_data.dosing_totals:
-        async_add_entities(
-            ChihirosDosingDailyTotalSensor(
-                chihiros_data.coordinator,
-                chihiros_data.device,
-                chihiros_data.dosing_totals,
-                pump_idx,
+        totals = chihiros_data.dosing_totals
+        entities: list[SensorEntity] = []
+        for pump_idx in range(totals.pump_count):
+            entities.append(
+                ChihirosDosingDailyTotalSensor(chihiros_data.coordinator, chihiros_data.device, totals, pump_idx)
             )
-            for pump_idx in range(chihiros_data.dosing_totals.pump_count)
-        )
+            entities.append(
+                ChihirosDosingLifetimeTotalSensor(chihiros_data.coordinator, chihiros_data.device, totals, pump_idx)
+            )
+            entities.append(
+                ChihirosDosingLifetimeCyclesSensor(chihiros_data.coordinator, chihiros_data.device, totals, pump_idx)
+            )
+        async_add_entities(entities)
         return
 
     async_add_entities(
@@ -194,10 +198,38 @@ class ChihirosNotificationSensor(
             raise HomeAssistantError(f"Failed to request status for {self._device.name}") from ex
 
 
-class ChihirosDosingDailyTotalSensor(SensorEntity):
-    """Sensor for locally tracked manual dosing total for today."""
+class ChihirosDosingSensorBase(SensorEntity):
+    """Shared base for locally tracked dosing counters."""
 
     _attr_should_poll = False
+
+    def __init__(
+        self,
+        coordinator: ChihirosDataUpdateCoordinator,
+        device: ChihirosClient,
+        totals: DosingDailyTotals,
+        pump_idx: int,
+        unique_id_suffix: str,
+        name_suffix: str,
+    ) -> None:
+        """Initialize the dosing counter sensor."""
+        self._device = device
+        self._totals = totals
+        self._pump_idx = pump_idx
+        self._attr_name = chihiros_entity_name(device, name_suffix)
+        self._attr_unique_id = chihiros_unique_id(coordinator.address, unique_id_suffix)
+        self._attr_device_info = chihiros_device_info(device, coordinator.address)
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to dosing total updates."""
+        self.async_on_remove(
+            async_dispatcher_connect(self.hass, self._totals.address_signal, self.async_write_ha_state)
+        )
+
+
+class ChihirosDosingDailyTotalSensor(ChihirosDosingSensorBase):
+    """Sensor for locally tracked manual dosing total for today."""
+
     _attr_device_class = SensorDeviceClass.VOLUME
     _attr_native_unit_of_measurement = UnitOfVolume.MILLILITERS
     _attr_suggested_display_precision = 1
@@ -209,25 +241,84 @@ class ChihirosDosingDailyTotalSensor(SensorEntity):
         totals: DosingDailyTotals,
         pump_idx: int,
     ) -> None:
-        """Initialize the dosing total sensor."""
-        self._device = device
-        self._totals = totals
-        self._pump_idx = pump_idx
+        """Initialize the daily dosing total sensor."""
         pump_number = pump_idx + 1
-        self._attr_name = chihiros_entity_name(device, f"Pump {pump_number} dosed today")
-        self._attr_unique_id = chihiros_unique_id(coordinator.address, f"dosing_pump_{pump_number}_dosed_today")
-        self._attr_device_info = chihiros_device_info(device, coordinator.address)
-
-    async def async_added_to_hass(self) -> None:
-        """Subscribe to dosing total updates."""
-        self.async_on_remove(
-            async_dispatcher_connect(self.hass, self._totals.address_signal, self.async_write_ha_state)
+        super().__init__(
+            coordinator,
+            device,
+            totals,
+            pump_idx,
+            f"dosing_pump_{pump_number}_dosed_today",
+            f"Pump {pump_number} dosed today",
         )
 
     @property
     def native_value(self) -> float:
         """Return today's tracked total."""
         return self._totals.total_ml(self._pump_idx)
+
+
+class ChihirosDosingLifetimeTotalSensor(ChihirosDosingSensorBase):
+    """Sensor for the lifetime dosed volume of one pump."""
+
+    _attr_device_class = SensorDeviceClass.VOLUME
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = UnitOfVolume.MILLILITERS
+    _attr_suggested_display_precision = 1
+
+    def __init__(
+        self,
+        coordinator: ChihirosDataUpdateCoordinator,
+        device: ChihirosClient,
+        totals: DosingDailyTotals,
+        pump_idx: int,
+    ) -> None:
+        """Initialize the lifetime dosing volume sensor."""
+        pump_number = pump_idx + 1
+        super().__init__(
+            coordinator,
+            device,
+            totals,
+            pump_idx,
+            f"dosing_pump_{pump_number}_total_ml",
+            f"Pump {pump_number} total ml",
+        )
+
+    @property
+    def native_value(self) -> float:
+        """Return the lifetime tracked total volume."""
+        return self._totals.lifetime_ml(self._pump_idx)
+
+
+class ChihirosDosingLifetimeCyclesSensor(ChihirosDosingSensorBase):
+    """Sensor for the lifetime dose count of one pump."""
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+    _attr_native_unit_of_measurement = "cycles"
+    _attr_suggested_display_precision = 0
+
+    def __init__(
+        self,
+        coordinator: ChihirosDataUpdateCoordinator,
+        device: ChihirosClient,
+        totals: DosingDailyTotals,
+        pump_idx: int,
+    ) -> None:
+        """Initialize the lifetime dosing cycles sensor."""
+        pump_number = pump_idx + 1
+        super().__init__(
+            coordinator,
+            device,
+            totals,
+            pump_idx,
+            f"dosing_pump_{pump_number}_total_cycles",
+            f"Pump {pump_number} total cycles",
+        )
+
+    @property
+    def native_value(self) -> int:
+        """Return the lifetime tracked dose count."""
+        return self._totals.lifetime_cycles(self._pump_idx)
 
 
 def _format_schedule_state(points: tuple[dict[str, Any], ...]) -> str:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,32 @@
+"""Test configuration for chihiros-led-control tests."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+def pytest_configure(config):
+    """Register custom markers."""
+    config.addinivalue_line("markers", "integration: tests that load the integration through Home Assistant")
+    config.addinivalue_line("markers", "unit: isolated tests that do not load a Home Assistant config entry")
+
+
+@pytest.fixture(autouse=True)
+def enable_event_loop_debug():
+    """Enable event loop debug mode (Python 3.10+ compatible).
+
+    Overrides the broken fixture from pytest-homeassistant-custom-component
+    which calls asyncio.get_event_loop() and fails on Python 3.14.
+    """
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_closed():
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+        loop.set_debug(True)
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        loop.set_debug(True)

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,245 @@
+"""Integration tests for ChihirosDataUpdateCoordinator behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+try:
+    from homeassistant.components.bluetooth import update_coordinator as bluetooth_update
+    from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+    from homeassistant.const import CONF_ADDRESS
+    from homeassistant.core import HomeAssistant
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    import custom_components.chihiros as chihiros_integration
+    from custom_components.chihiros.const import DOMAIN
+    from custom_components.chihiros.coordinator import (
+        ATTR_FIRMWARE_VERSION,
+        ATTR_RUNTIME_MINUTES,
+        ATTR_SCHEDULE_POINTS,
+        ChihirosDataUpdateCoordinator,
+    )
+    from custom_components.chihiros.runtime import ChihirosRuntime
+
+    # Capture the real unbound method before any per-test monkeypatching so the
+    # idempotency test can restore it after the setup harness patches it out.
+    _REAL_ASYNC_START_BLUETOOTH = ChihirosDataUpdateCoordinator.async_start_bluetooth
+except ImportError as err:
+    pytest.skip(
+        f"Home Assistant test group is not installed or is incompatible: {err}",
+        allow_module_level=True,
+    )
+
+from custom_components.chihiros.vendor.chihiros_led_control.models import RGB_CHANNELS, DeviceModel
+from custom_components.chihiros.vendor.chihiros_led_control.protocol import (
+    ParsedNotification,
+    RuntimeNotification,
+    SchedulePoint,
+    ScheduleSnapshotNotification,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("enable_custom_integrations", "mock_bluetooth"),
+]
+
+TEST_ADDRESS = "FA:CE:C0:00:30:01"
+
+
+class _TrackingClient:
+    """Minimal mock Chihiros client for coordinator tests."""
+
+    def __init__(self) -> None:
+        self.model = DeviceModel("Test RGB", ("TEST-RGB",), RGB_CHANNELS)
+        self.query_status_calls = 0
+        self._callbacks: set[Callable[[ParsedNotification], None]] = set()
+
+    @property
+    def address(self) -> str:
+        return TEST_ADDRESS
+
+    @property
+    def name(self) -> str:
+        return "Test Chihiros"
+
+    @property
+    def model_name(self) -> str:
+        return self.model.name
+
+    @property
+    def colors(self) -> dict[str, int]:
+        return dict(self.model.color_channels)
+
+    def add_notification_callback(self, callback: Callable[[ParsedNotification], None]) -> Callable[[], None]:
+        self._callbacks.add(callback)
+
+        def remove() -> None:
+            self._callbacks.discard(callback)
+
+        return remove
+
+    async def query_status(self) -> None:
+        self.query_status_calls += 1
+
+    async def disconnect(self) -> None:
+        pass
+
+
+async def _setup(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[ConfigEntry, _TrackingClient, ChihirosDataUpdateCoordinator]:
+    """Set up the integration and return the tracking coordinator."""
+    client = _TrackingClient()
+
+    async def resolve_runtime(_hass: HomeAssistant, _entry: ConfigEntry) -> ChihirosRuntime:
+        return ChihirosRuntime(client=client, address=TEST_ADDRESS, always_available=True)
+
+    monkeypatch.setattr(chihiros_integration, "resolve_chihiros_runtime", resolve_runtime)
+    monkeypatch.setattr(bluetooth_update, "async_address_present", lambda *_a, **_k: True)
+    monkeypatch.setattr(ChihirosDataUpdateCoordinator, "async_start_bluetooth", lambda _self: None)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=client.name,
+        unique_id=TEST_ADDRESS,
+        data={CONF_ADDRESS: TEST_ADDRESS},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert entry.state is ConfigEntryState.LOADED
+
+    coordinator: ChihirosDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id].coordinator
+    return entry, client, coordinator
+
+
+async def _flush() -> None:
+    """Yield to pending callbacks."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+async def test_async_request_status_calls_client_query_status(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """async_request_status forwards to the client query_status."""
+    _entry, client, coordinator = await _setup(hass, monkeypatch)
+
+    before = client.query_status_calls
+    await coordinator.async_request_status()
+    assert client.query_status_calls == before + 1
+
+
+async def test_async_set_auto_mode_noop_when_unchanged_and_updates_when_changed(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting the same mode is a no-op; changing it notifies listeners."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch)
+    updates = 0
+
+    def _listener() -> None:
+        nonlocal updates
+        updates += 1
+
+    coordinator.async_add_listener(_listener)
+
+    # Initial mode is False; setting False again is a no-op (no listener update).
+    coordinator.async_set_auto_mode(False)
+    assert updates == 0
+    assert coordinator.auto_mode is False
+
+    # Setting True flips the mode and notifies listeners.
+    coordinator.async_set_auto_mode(True)
+    assert coordinator.auto_mode is True
+    assert updates == 1
+
+
+async def test_async_start_bluetooth_is_idempotent(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """async_start_bluetooth only registers the bluetooth callback once."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch)
+
+    # Restore the real async_start_bluetooth (the setup harness patches it to a
+    # no-op) so the idempotency guard can be exercised.
+    monkeypatch.setattr(ChihirosDataUpdateCoordinator, "async_start_bluetooth", _REAL_ASYNC_START_BLUETOOTH)
+    starts: list[bool] = []
+
+    def _fake_start() -> Callable[[], None]:
+        starts.append(True)
+        return lambda: None
+
+    monkeypatch.setattr(coordinator, "async_start", _fake_start)
+    coordinator._remove_bluetooth_callback = None
+
+    coordinator.async_start_bluetooth()
+    coordinator.async_start_bluetooth()
+    assert starts == [True]
+
+
+async def test_async_close_unregisters_callbacks_and_drops_notifications(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Closing the coordinator removes callbacks and ignores later notifications."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch)
+
+    captured: list[Any] = []
+    coordinator.async_add_listener(lambda: captured.append("update"))
+
+    # Idempotent start so a real bluetooth callback is registered, then close.
+    monkeypatch.setattr(coordinator, "async_start", lambda: None)
+    coordinator.async_start_bluetooth()
+
+    coordinator.async_close()
+    # A second close must not raises (handles the None bluetooth callback).
+    coordinator.async_close()
+
+    # Notifications queued after close are dropped (no listener update).
+    coordinator._async_handle_notification(RuntimeNotification(23, 511, bytes.fromhex("5b 17 0a 00 01 0a 01 ff")))
+    assert captured == []
+
+
+async def test_handle_runtime_notification_populates_data(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A runtime notification stores firmware/runtime diagnostic data."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch)
+
+    coordinator._async_handle_notification(RuntimeNotification(23, 511, bytes.fromhex("5b 17 0a 00 01 0a 01 ff")))
+    await _flush()
+
+    assert coordinator.data[ATTR_FIRMWARE_VERSION] == 23
+    assert coordinator.data[ATTR_RUNTIME_MINUTES] == 511
+
+
+async def test_handle_schedule_snapshot_notification_populates_data(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A schedule snapshot notification stores schedule points."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch)
+
+    coordinator._async_handle_notification(
+        ScheduleSnapshotNotification(
+            23,
+            (SchedulePoint(8, 5, {"red": 10}),),
+            bytes.fromhex("5b 17 0a 00 01 0a 01 ff"),
+        )
+    )
+    await _flush()
+
+    assert coordinator.data[ATTR_FIRMWARE_VERSION] == 23
+    points = coordinator.data[ATTR_SCHEDULE_POINTS]
+    assert points == ({"time": "08:05", "levels": {"red": 10}},)

--- a/tests/test_dosing.py
+++ b/tests/test_dosing.py
@@ -1,0 +1,142 @@
+"""Unit tests for dosing daily-total storage and reset behavior."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+import pytest
+
+pytest.importorskip("homeassistant", reason="Home Assistant test group is not installed")
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.chihiros.dosing import (
+    PUMP_COUNT,
+    SIGNAL_DOSING_TOTALS_UPDATED,
+    DosingDailyTotals,
+    _coerce_total,
+    normalize_pump_count,
+)
+
+
+def test_normalize_pump_count_defaults_invalid_values() -> None:
+    """Unsupported or non-numeric values fall back to the default pump count."""
+    assert normalize_pump_count("2") == 2
+    assert normalize_pump_count("4") == 4
+    assert normalize_pump_count("3") == PUMP_COUNT
+    assert normalize_pump_count(None) == PUMP_COUNT
+    assert normalize_pump_count("not a number") == PUMP_COUNT
+
+
+def test_coerce_total_tolerates_garbage() -> None:
+    """_coerce_total rounds valid numbers and rejects non-numeric input to 0.0."""
+    assert _coerce_total(2.56) == 2.6
+    assert _coerce_total("3.4") == 3.4
+    assert _coerce_total(None) == 0.0
+    assert _coerce_total("nope") == 0.0
+
+
+@pytest.mark.asyncio
+async def test_async_load_restores_today_totals(hass: Any) -> None:
+    """A stored dict for today restores per-pump totals using _coerce_total."""
+    totals = DosingDailyTotals(hass, "FA:CE:C0:FF:00:01", pump_count=2)
+
+    async def _load() -> dict[str, Any]:
+        return {
+            "date": dt_util.now().date().isoformat(),
+            "totals_ml": [1.5, "2.7", "bad"],
+        }
+
+    totals._store.async_load = _load  # type: ignore[assignment]
+
+    await totals.async_load()
+
+    assert totals.total_ml(0) == 1.5
+    assert totals.total_ml(1) == 2.7
+    # The stored list has a third entry; pump_count=2 so only two are read,
+    # and out-of-range indices return the coerced stored value (or 0.0).
+    with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
+        totals.total_ml(2)
+
+
+@pytest.mark.asyncio
+async def test_async_load_stale_date_resets_totals(hass: Any) -> None:
+    """A stored dict with a stale date triggers an async_reset of the totals."""
+    saved: list[dict[str, Any]] = []
+    totals = DosingDailyTotals(hass, "FA:CE:C0:FF:00:02", pump_count=2)
+
+    async def _load() -> dict[str, Any]:
+        return {"date": "1999-01-01", "totals_ml": [9.9, 8.8]}
+
+    totals._store.async_load = _load  # type: ignore[assignment]
+
+    async def _save(data: dict[str, Any]) -> None:
+        saved.append(data)
+
+    totals._store.async_save = _save  # type: ignore[assignment]
+
+    await totals.async_load()
+
+    assert totals.total_ml(0) == 0.0
+    assert totals.total_ml(1) == 0.0
+    # async_reset persists the zeroed totals for today.
+    assert saved and saved[0]["date"] == dt_util.now().date().isoformat()
+    assert saved[0]["totals_ml"] == [0.0, 0.0]
+
+
+@pytest.mark.asyncio
+async def test_async_add_dose_accumulates_and_persists(hass: Any) -> None:
+    """async_add_dose accumulates onto today's running total and saves it."""
+    saved: list[dict[str, Any]] = []
+    totals = DosingDailyTotals(hass, "FA:CE:C0:FF:00:03", pump_count=2)
+
+    async def _save(data: dict[str, Any]) -> None:
+        saved.append(data)
+
+    totals._store.async_save = _save  # type: ignore[assignment]
+    await totals.async_load()
+
+    await totals.async_add_dose(0, 2.5)
+    await totals.async_add_dose(0, 1.1)
+
+    assert totals.total_ml(0) == 3.6
+    assert totals.total_ml(1) == 0.0
+    assert any(entry["totals_ml"][0] == 3.6 for entry in saved)
+    with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
+        await totals.async_add_dose(5, 1.0)
+
+
+@pytest.mark.asyncio
+async def test_address_signal_and_async_close_cancel_schedule(hass: Any) -> None:
+    """The dispatcher signal is address-scoped and close cancels the reset timer."""
+    address = "FA:CE:C0:FF:00:04"
+    totals = DosingDailyTotals(hass, address, pump_count=2)
+    await totals.async_load()
+
+    assert totals.address_signal == f"{SIGNAL_DOSING_TOTALS_UPDATED}_{address.lower()}"
+    assert totals._unsub_midnight_reset is not None
+
+    totals.async_close()
+    assert totals._unsub_midnight_reset is None
+    # A second close is a no-op (no error).
+    totals.async_close()
+
+
+@pytest.mark.asyncio
+async def test_midnight_reset_resets_totals_and_reschedules(hass: Any) -> None:
+    """_async_midnight_reset zeros totals and schedules the next reset."""
+    totals = DosingDailyTotals(hass, "FA:CE:C0:FF:00:05", pump_count=2)
+    await totals.async_load()
+    await totals.async_add_dose(0, 5.0)
+    assert totals.total_ml(0) == 5.0
+
+    first_reset_handle = totals._unsub_midnight_reset
+
+    await totals._async_midnight_reset(dt_util.utcnow() + timedelta(days=1))
+
+    assert totals.total_ml(0) == 0.0
+    # The reset re-schedules a fresh midnight callback.
+    assert totals._unsub_midnight_reset is not None
+    assert totals._unsub_midnight_reset is not first_reset_handle
+    totals.async_close()

--- a/tests/test_dosing.py
+++ b/tests/test_dosing.py
@@ -19,6 +19,10 @@ from custom_components.chihiros.dosing import (
     normalize_pump_count,
 )
 
+pytestmark = [
+    pytest.mark.integration,
+]
+
 
 def test_normalize_pump_count_defaults_invalid_values() -> None:
     """Unsupported or non-numeric values fall back to the default pump count."""

--- a/tests/test_dosing.py
+++ b/tests/test_dosing.py
@@ -15,7 +15,9 @@ from custom_components.chihiros.dosing import (
     PUMP_COUNT,
     SIGNAL_DOSING_TOTALS_UPDATED,
     DosingDailyTotals,
+    _coerce_cycles_list,
     _coerce_total,
+    _coerce_total_list,
     normalize_pump_count,
 )
 
@@ -41,6 +43,21 @@ def test_coerce_total_tolerates_garbage() -> None:
     assert _coerce_total("nope") == 0.0
 
 
+def test_coerce_total_list_handles_garbage_and_short_lists() -> None:
+    """_coerce_total_list returns a fixed-length list safeguarding against bad/short stored data."""
+    assert _coerce_total_list(None, 2) == [0.0, 0.0]
+    assert _coerce_total_list([1.5, "2.7", "bad"], 2) == [1.5, 2.7]
+    assert _coerce_total_list([4.0], 3) == [4.0, 0.0, 0.0]
+
+
+def test_coerce_cycles_list_handles_garbage_and_short_lists() -> None:
+    """_coerce_cycles_list rounds stored counts and defaults missing/invalid entries to 0."""
+    assert _coerce_cycles_list(None, 2) == [0, 0]
+    assert _coerce_cycles_list([1, "2", "bad"], 2) == [1, 2]
+    assert _coerce_cycles_list([3.6], 3) == [4, 0, 0]
+    assert _coerce_cycles_list([1, 2, 3, 4], 2) == [1, 2]
+
+
 @pytest.mark.asyncio
 async def test_async_load_restores_today_totals(hass: Any) -> None:
     """A stored dict for today restores per-pump totals using _coerce_total."""
@@ -50,6 +67,8 @@ async def test_async_load_restores_today_totals(hass: Any) -> None:
         return {
             "date": dt_util.now().date().isoformat(),
             "totals_ml": [1.5, "2.7", "bad"],
+            "lifetime_ml": [10.0, "20.5"],
+            "lifetime_cycles": [3, "4"],
         }
 
     totals._store.async_load = _load  # type: ignore[assignment]
@@ -58,10 +77,18 @@ async def test_async_load_restores_today_totals(hass: Any) -> None:
 
     assert totals.total_ml(0) == 1.5
     assert totals.total_ml(1) == 2.7
+    assert totals.lifetime_ml(0) == 10.0
+    assert totals.lifetime_ml(1) == round(20.5, 1)
+    assert totals.lifetime_cycles(0) == 3
+    assert totals.lifetime_cycles(1) == 4
     # The stored list has a third entry; pump_count=2 so only two are read,
     # and out-of-range indices return the coerced stored value (or 0.0).
     with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
         totals.total_ml(2)
+    with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
+        totals.lifetime_ml(2)
+    with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
+        totals.lifetime_cycles(2)
 
 
 @pytest.mark.asyncio
@@ -71,7 +98,12 @@ async def test_async_load_stale_date_resets_totals(hass: Any) -> None:
     totals = DosingDailyTotals(hass, "FA:CE:C0:FF:00:02", pump_count=2)
 
     async def _load() -> dict[str, Any]:
-        return {"date": "1999-01-01", "totals_ml": [9.9, 8.8]}
+        return {
+            "date": "1999-01-01",
+            "totals_ml": [9.9, 8.8],
+            "lifetime_ml": [12.3, 4.5],
+            "lifetime_cycles": [7, 1],
+        }
 
     totals._store.async_load = _load  # type: ignore[assignment]
 
@@ -84,9 +116,16 @@ async def test_async_load_stale_date_resets_totals(hass: Any) -> None:
 
     assert totals.total_ml(0) == 0.0
     assert totals.total_ml(1) == 0.0
-    # async_reset persists the zeroed totals for today.
+    # Lifetime counters are preserved across the daily reset.
+    assert totals.lifetime_ml(0) == round(12.3, 1)
+    assert totals.lifetime_ml(1) == round(4.5, 1)
+    assert totals.lifetime_cycles(0) == 7
+    assert totals.lifetime_cycles(1) == 1
+    # async_reset persists the zeroed totals for today while keeping lifetime data.
     assert saved and saved[0]["date"] == dt_util.now().date().isoformat()
     assert saved[0]["totals_ml"] == [0.0, 0.0]
+    assert saved[0]["lifetime_ml"] == [round(12.3, 1), round(4.5, 1)]
+    assert saved[0]["lifetime_cycles"] == [7, 1]
 
 
 @pytest.mark.asyncio
@@ -106,7 +145,13 @@ async def test_async_add_dose_accumulates_and_persists(hass: Any) -> None:
 
     assert totals.total_ml(0) == 3.6
     assert totals.total_ml(1) == 0.0
+    assert totals.lifetime_ml(0) == 3.6
+    assert totals.lifetime_ml(1) == 0.0
+    assert totals.lifetime_cycles(0) == 2
+    assert totals.lifetime_cycles(1) == 0
     assert any(entry["totals_ml"][0] == 3.6 for entry in saved)
+    assert saved[-1]["lifetime_ml"] == [3.6, 0.0]
+    assert saved[-1]["lifetime_cycles"] == [2, 0]
     with pytest.raises(ValueError, match="Pump index must be between 0 and 1"):
         await totals.async_add_dose(5, 1.0)
 
@@ -134,12 +179,17 @@ async def test_midnight_reset_resets_totals_and_reschedules(hass: Any) -> None:
     await totals.async_load()
     await totals.async_add_dose(0, 5.0)
     assert totals.total_ml(0) == 5.0
+    assert totals.lifetime_ml(0) == 5.0
+    assert totals.lifetime_cycles(0) == 1
 
     first_reset_handle = totals._unsub_midnight_reset
 
     await totals._async_midnight_reset(dt_util.utcnow() + timedelta(days=1))
 
     assert totals.total_ml(0) == 0.0
+    # Lifetime counters survive the daily reset.
+    assert totals.lifetime_ml(0) == 5.0
+    assert totals.lifetime_cycles(0) == 1
     # The reset re-schedules a fresh midnight callback.
     assert totals._unsub_midnight_reset is not None
     assert totals._unsub_midnight_reset is not first_reset_handle

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -1,0 +1,314 @@
+"""Integration tests for the Chihiros fan platform."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+try:
+    from homeassistant.components.bluetooth import update_coordinator as bluetooth_update
+    from homeassistant.components.fan import (
+        ATTR_PERCENTAGE,
+        SERVICE_SET_PERCENTAGE,
+    )
+    from homeassistant.components.fan import (
+        DOMAIN as FAN_DOMAIN,
+    )
+    from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+    from homeassistant.const import ATTR_ENTITY_ID, CONF_ADDRESS, STATE_OFF, STATE_ON
+    from homeassistant.core import HomeAssistant, State
+    from homeassistant.exceptions import HomeAssistantError
+    from homeassistant.helpers import entity_registry as er
+    from homeassistant.helpers.restore_state import StoredState
+    from homeassistant.helpers.restore_state import async_get as async_get_restore_data
+    from homeassistant.util import dt as dt_util
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    import custom_components.chihiros as chihiros_integration
+    from custom_components.chihiros.const import DOMAIN
+    from custom_components.chihiros.coordinator import ATTR_FAN_RPM, ChihirosDataUpdateCoordinator
+    from custom_components.chihiros.runtime import ChihirosRuntime
+except ImportError as err:
+    pytest.skip(
+        f"Home Assistant test group is not installed or is incompatible: {err}",
+        allow_module_level=True,
+    )
+
+from custom_components.chihiros.vendor.chihiros_led_control.models import (
+    RGB_CHANNELS,
+    WRGB_CHANNELS,
+    DeviceModel,
+)
+from custom_components.chihiros.vendor.chihiros_led_control.protocol import (
+    FanStatusNotification,
+    ParsedNotification,
+)
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("enable_custom_integrations", "mock_bluetooth"),
+]
+
+TEST_ADDRESS = "FA:CE:C0:00:20:01"
+FAN_MODEL = DeviceModel("WRGB VIVID III", ("DYVVD3",), WRGB_CHANNELS, has_fan=True)
+RGB_MODEL = DeviceModel("Test RGB", ("TEST-RGB",), RGB_CHANNELS)
+
+
+class _TrackingClient:
+    """Minimal mock Chihiros client for fan entity tests."""
+
+    def __init__(self, model: DeviceModel) -> None:
+        self.model = model
+        self.fan_speed_calls: list[int] = []
+        self._callbacks: set[Callable[[ParsedNotification], None]] = set()
+        self.set_fan_speed_exception: Exception | None = None
+
+    @property
+    def address(self) -> str:
+        return TEST_ADDRESS
+
+    @property
+    def name(self) -> str:
+        return "Test Chihiros"
+
+    @property
+    def model_name(self) -> str:
+        return self.model.name
+
+    @property
+    def colors(self) -> dict[str, int]:
+        return dict(self.model.color_channels)
+
+    def add_notification_callback(self, callback: Callable[[ParsedNotification], None]) -> Callable[[], None]:
+        self._callbacks.add(callback)
+
+        def remove() -> None:
+            self._callbacks.discard(callback)
+
+        return remove
+
+    async def set_fan_speed(self, speed_percent: int) -> None:
+        if self.set_fan_speed_exception is not None:
+            raise self.set_fan_speed_exception
+        self.fan_speed_calls.append(speed_percent)
+
+    async def disconnect(self) -> None:
+        pass
+
+
+async def _setup(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    model: DeviceModel = FAN_MODEL,
+    *,
+    always_available: bool = True,
+) -> tuple[ConfigEntry, _TrackingClient, ChihirosDataUpdateCoordinator]:
+    """Set up the integration with a fan-capable device model."""
+    client = _TrackingClient(model)
+
+    async def resolve_runtime(_hass: HomeAssistant, _entry: ConfigEntry) -> ChihirosRuntime:
+        return ChihirosRuntime(client=client, address=TEST_ADDRESS, always_available=always_available)
+
+    monkeypatch.setattr(chihiros_integration, "resolve_chihiros_runtime", resolve_runtime)
+    monkeypatch.setattr(bluetooth_update, "async_address_present", lambda *_a, **_k: True)
+    monkeypatch.setattr(ChihirosDataUpdateCoordinator, "async_start_bluetooth", lambda _self: None)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=client.name,
+        unique_id=TEST_ADDRESS,
+        data={CONF_ADDRESS: TEST_ADDRESS},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert entry.state is ConfigEntryState.LOADED
+
+    coordinator: ChihirosDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id].coordinator
+    return entry, client, coordinator
+
+
+async def _flush() -> None:
+    """Yield to pending state-write callbacks."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+def _entity_id(registry: er.EntityRegistry) -> str:
+    """Look up the fan entity id and assert it exists."""
+    entity_id = registry.async_get_entity_id(FAN_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_fan")
+    assert entity_id is not None
+    return entity_id
+
+
+def _prime_restore_state(hass: HomeAssistant, entity_id: str, state: State) -> None:
+    """Inject a stored last-state so the next entity load restores from it."""
+    async_get_restore_data(hass).last_states[entity_id] = StoredState(state, None, dt_util.utcnow())
+
+
+async def _reload_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    prime: Callable[[], None] | None = None,
+) -> None:
+    """Unload and re-setup a config entry so entities restore from stored state."""
+    await hass.config_entries.async_unload(entry.entry_id)
+    await _flush()
+    if prime is not None:
+        prime()
+    await hass.config_entries.async_setup(entry.entry_id)
+    await _flush()
+    assert entry.state is ConfigEntryState.LOADED
+
+
+async def test_fan_entity_created_for_fan_model(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fan-equipped model gets a fan entity."""
+    _entry, _client, _coordinator = await _setup(hass, monkeypatch, FAN_MODEL)
+    registry = er.async_get(hass)
+    assert _entity_id(registry) is not None
+
+
+async def test_fan_set_percentage_turn_on_and_turn_off_drive_client(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """set_percentage/turn_on/turn_off forward to set_fan_speed and update state.
+
+    turn_on/turn_off are invoked through the entity object directly because the
+    fan entity only advertises SET_SPEED (HA's fan services require explicit
+    TURN_ON/TURN_OFF feature flags the entity does not set).
+    """
+    _entry, client, _coordinator = await _setup(hass, monkeypatch, FAN_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry)
+    entity = hass.data[FAN_DOMAIN].get_entity(entity_id)
+    assert entity is not None
+
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 50},
+        blocking=True,
+    )
+    await _flush()
+
+    assert client.fan_speed_calls == [50]
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PERCENTAGE] == 50
+
+    # turn_on without percentage restores the previous percentage
+    await entity.async_turn_on()
+    await _flush()
+    assert client.fan_speed_calls == [50, 50]
+
+    await entity.async_turn_off()
+    await _flush()
+    assert client.fan_speed_calls == [50, 50, 0]
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+    assert state.attributes[ATTR_PERCENTAGE] == 0
+
+
+async def test_fan_set_speed_failure_raises_and_keeps_previous_state(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BLE failure during set_percentage raises HomeAssistantError and keeps state."""
+    _entry, client, _coordinator = await _setup(hass, monkeypatch, FAN_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry)
+
+    # Establish a known on state at 40% first.
+    await hass.services.async_call(
+        FAN_DOMAIN,
+        SERVICE_SET_PERCENTAGE,
+        {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 40},
+        blocking=True,
+    )
+    await _flush()
+
+    client.set_fan_speed_exception = RuntimeError("ble write failed")
+    with pytest.raises(HomeAssistantError, match="Failed to set fan speed"):
+        await hass.services.async_call(
+            FAN_DOMAIN,
+            SERVICE_SET_PERCENTAGE,
+            {ATTR_ENTITY_ID: entity_id, ATTR_PERCENTAGE: 80},
+            blocking=True,
+        )
+    await _flush()
+
+    # The failed write must not have advanced the reported percentage.
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_PERCENTAGE] == 40
+
+
+async def test_fan_restores_percentage_from_last_state(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fan entity restores its percentage on reload."""
+    entry, _client, _coordinator = await _setup(hass, monkeypatch, FAN_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry)
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            State(entity_id, STATE_ON, {"percentage": 65}),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_PERCENTAGE] == 65
+
+
+async def test_fan_extra_state_attributes_reflect_fan_status_notification(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fan status notification surfaces fan_rpm as an extra state attribute."""
+    _entry, _client, coordinator = await _setup(hass, monkeypatch, FAN_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry)
+
+    # No notification yet -> no fan_rpm attribute.
+    assert hass.states.get(entity_id).attributes.get(ATTR_FAN_RPM) is None
+
+    notification = FanStatusNotification(
+        firmware_version=27,
+        fan_rpm=1234,
+        temperature_celsius=25,
+        raw=bytes.fromhex("5b 1b 10 00 01 0b 04 d2 19 00 01 00 00 00 00 00 48 22"),
+    )
+    coordinator._async_handle_notification(notification)
+    await _flush()
+
+    assert hass.states.get(entity_id).attributes[ATTR_FAN_RPM] == 1234
+
+
+async def test_fan_available_when_not_always_available(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The fan entity delegates to coordinator availability when not always available."""
+    _entry, _client, _coordinator = await _setup(hass, monkeypatch, FAN_MODEL, always_available=False)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry)
+
+    await _flush()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != "unavailable"

--- a/tests/test_home_assistant_integration.py
+++ b/tests/test_home_assistant_integration.py
@@ -11,8 +11,19 @@ import pytest
 
 try:
     from homeassistant.components.bluetooth import update_coordinator as bluetooth_update
+    from homeassistant.components.button import DOMAIN as BUTTON_DOMAIN
+    from homeassistant.components.button import SERVICE_PRESS
     from homeassistant.components.light import ATTR_BRIGHTNESS
     from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
+    from homeassistant.components.number import (
+        ATTR_VALUE as ATTR_NUMBER_VALUE,
+    )
+    from homeassistant.components.number import (
+        DOMAIN as NUMBER_DOMAIN,
+    )
+    from homeassistant.components.number import (
+        SERVICE_SET_VALUE,
+    )
     from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
     from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
     from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -504,3 +515,123 @@ async def test_schedule_services_drive_client(
     assert client.reset_settings_calls == 2
     assert client.add_setting_calls[-2]["max_brightness"] == 40
     assert client.add_setting_calls[-1]["max_brightness"] == {"red": 10, "green": 20, "blue": 30}
+
+
+async def test_dosing_button_press_triggers_dose_with_configured_volume(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pressing a pump's dose button doses the volume configured on its number."""
+    dosing_client = TrackingDosingClient()
+    entry, client = await _setup_entry(hass, monkeypatch, dosing_client)
+    assert isinstance(client, TrackingDosingClient)
+    entity_registry = er.async_get(hass)
+    pump_1_number = _entity_id(entity_registry, NUMBER_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_1_dose_volume")
+    pump_1_button = _entity_id(entity_registry, BUTTON_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_1_dose")
+
+    # Configure pump 1's dose volume to 3.0 mL.
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: pump_1_number, ATTR_NUMBER_VALUE: 3.0},
+        blocking=True,
+    )
+    await _flush_ha_state_updates()
+
+    await hass.services.async_call(BUTTON_DOMAIN, SERVICE_PRESS, {ATTR_ENTITY_ID: pump_1_button}, blocking=True)
+    await _flush_ha_state_updates()
+
+    assert client.dose_ml_calls == [(0, 3.0)]
+    # The dosing total sensor reflects the dosed volume.
+    pump_1_sensor = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_1_dosed_today")
+    assert hass.states.get(pump_1_sensor).state == "3.0"
+
+
+async def test_dosing_number_set_value_updates_runtime_volume(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Setting a pump dose volume number updates the persisted runtime volume."""
+    dosing_client = TrackingDosingClient()
+    entry, client = await _setup_entry(hass, monkeypatch, dosing_client)
+    assert isinstance(client, TrackingDosingClient)
+    entity_registry = er.async_get(hass)
+    pump_1_number = _entity_id(entity_registry, NUMBER_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_1_dose_volume")
+
+    # Initial value is the integration default of 1.0 mL per pump.
+    assert hass.states.get(pump_1_number).state == "1.0"
+
+    await hass.services.async_call(
+        NUMBER_DOMAIN,
+        SERVICE_SET_VALUE,
+        {ATTR_ENTITY_ID: pump_1_number, ATTR_NUMBER_VALUE: 5.5},
+        blocking=True,
+    )
+    await _flush_ha_state_updates()
+
+    assert hass.states.get(pump_1_number).state == "5.5"
+    assert hass.data[DOMAIN][entry.entry_id].dosing_volumes[0] == 5.5
+
+
+async def test_dosing_number_restore_skips_out_of_range_and_invalid(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring an out-of-range or non-numeric value leaves the default in place."""
+    dosing_client = TrackingDosingClient()
+    entry, client = await _setup_entry(hass, monkeypatch, dosing_client)
+    assert isinstance(client, TrackingDosingClient)
+    entity_registry = er.async_get(hass)
+    pump_1_number = _entity_id(entity_registry, NUMBER_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_1_dose_volume")
+    pump_2_number = _entity_id(entity_registry, NUMBER_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_2_dose_volume")
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await _flush_ha_state_updates()
+
+    # Prime restore: out-of-range for pump 1, garbage string for pump 2.
+    from homeassistant.core import State
+    from homeassistant.helpers.restore_state import StoredState
+    from homeassistant.helpers.restore_state import async_get as async_get_restore_data
+    from homeassistant.util import dt as dt_util
+
+    restore_data = async_get_restore_data(hass)
+    restore_data.last_states[pump_1_number] = StoredState(State(pump_1_number, "9999.0"), None, dt_util.utcnow())
+    restore_data.last_states[pump_2_number] = StoredState(State(pump_2_number, "not a number"), None, dt_util.utcnow())
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await _flush_ha_state_updates()
+    assert entry.state is ConfigEntryState.LOADED
+
+    # Both rejected restores keep the integration default of 1.0 mL.
+    assert hass.states.get(pump_1_number).state == "1.0"
+    assert hass.states.get(pump_2_number).state == "1.0"
+
+
+async def test_dosing_number_restore_valid_value(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring a valid in-range volume is applied on reload."""
+    dosing_client = TrackingDosingClient()
+    entry, client = await _setup_entry(hass, monkeypatch, dosing_client)
+    assert isinstance(client, TrackingDosingClient)
+    entity_registry = er.async_get(hass)
+    pump_3_number = _entity_id(entity_registry, NUMBER_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_3_dose_volume")
+
+    await hass.config_entries.async_unload(entry.entry_id)
+    await _flush_ha_state_updates()
+
+    from homeassistant.core import State
+    from homeassistant.helpers.restore_state import StoredState
+    from homeassistant.helpers.restore_state import async_get as async_get_restore_data
+    from homeassistant.util import dt as dt_util
+
+    restore_data = async_get_restore_data(hass)
+    restore_data.last_states[pump_3_number] = StoredState(State(pump_3_number, "3.25"), None, dt_util.utcnow())
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await _flush_ha_state_updates()
+    assert entry.state is ConfigEntryState.LOADED
+
+    # Restored value is rounded to one decimal place.
+    assert hass.states.get(pump_3_number).state == "3.2"

--- a/tests/test_home_assistant_integration.py
+++ b/tests/test_home_assistant_integration.py
@@ -292,17 +292,13 @@ async def test_config_entry_sets_up_entities_services_status_and_unloads(
     for service in (SERVICE_ADD_SCHEDULE, SERVICE_REMOVE_SCHEDULE, SERVICE_RESET_SCHEDULE, SERVICE_SET_SCHEDULE):
         assert hass.services.has_service(DOMAIN, service)
 
-    red_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_red")
-    green_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_green")
-    blue_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_blue")
+    rgb_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_rgb")
     auto_switch = _entity_id(entity_registry, SWITCH_DOMAIN, f"{TEST_ADDRESS}_auto_mode")
     firmware_sensor = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_firmware_version")
     schedule_sensor = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_schedule_points")
     notification_sensor = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_last_notification")
 
-    assert hass.states.get(red_light) is not None
-    assert hass.states.get(green_light) is not None
-    assert hass.states.get(blue_light) is not None
+    assert hass.states.get(rgb_light) is not None
     assert hass.states.get(auto_switch).state == STATE_OFF
     assert hass.states.get(firmware_sensor).state == "23"
     assert hass.states.get(schedule_sensor).state == "08:00 15%; 12:00 70%"
@@ -328,20 +324,21 @@ async def test_light_and_auto_mode_services_drive_client(
     """Drive light and switch behavior through Home Assistant services."""
     _entry, client = await _setup_entry(hass, monkeypatch)
     entity_registry = er.async_get(hass)
-    red_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_red")
+    rgb_light = _entity_id(entity_registry, LIGHT_DOMAIN, f"{TEST_ADDRESS}_rgb")
     auto_switch = _entity_id(entity_registry, SWITCH_DOMAIN, f"{TEST_ADDRESS}_auto_mode")
 
     await hass.services.async_call(
         LIGHT_DOMAIN,
         SERVICE_TURN_ON,
-        {ATTR_ENTITY_ID: red_light, ATTR_BRIGHTNESS: 128},
+        {ATTR_ENTITY_ID: rgb_light, ATTR_BRIGHTNESS: 128},
         blocking=True,
     )
     await _flush_ha_state_updates()
 
-    assert client.brightness_calls[-1] == {"red": 51}
-    assert hass.states.get(red_light).state == STATE_ON
-    assert hass.states.get(red_light).attributes[ATTR_BRIGHTNESS] == 128
+    # Brightness scales the default white (255,255,255) equally across RGB channels.
+    assert client.brightness_calls[-1] == {"red": 51, "green": 51, "blue": 51}
+    assert hass.states.get(rgb_light).state == STATE_ON
+    assert hass.states.get(rgb_light).attributes[ATTR_BRIGHTNESS] == 128
     assert hass.states.get(auto_switch).state == STATE_OFF
 
     await hass.services.async_call(SWITCH_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: auto_switch}, blocking=True)
@@ -350,11 +347,11 @@ async def test_light_and_auto_mode_services_drive_client(
     assert client.auto_mode_calls and isinstance(client.auto_mode_calls[-1], datetime)
     assert hass.states.get(auto_switch).state == STATE_ON
 
-    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: red_light}, blocking=True)
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: rgb_light}, blocking=True)
     await _flush_ha_state_updates()
 
-    assert client.brightness_calls[-1] == {"red": 0}
-    assert hass.states.get(red_light).state == STATE_OFF
+    assert client.brightness_calls[-1] == {"red": 0, "green": 0, "blue": 0}
+    assert hass.states.get(rgb_light).state == STATE_OFF
     assert hass.states.get(auto_switch).state == STATE_OFF
 
     await hass.services.async_call(SWITCH_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: auto_switch}, blocking=True)

--- a/tests/test_home_assistant_integration.py
+++ b/tests/test_home_assistant_integration.py
@@ -382,9 +382,13 @@ async def test_manual_dose_service_updates_persisted_daily_total_sensor(
     assert isinstance(client, TrackingDosingClient)
     entity_registry = er.async_get(hass)
     pump_2_sensor = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_2_dosed_today")
+    pump_2_lifetime_ml = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_2_total_ml")
+    pump_2_lifetime_cycles = _entity_id(entity_registry, SENSOR_DOMAIN, f"{TEST_ADDRESS}_dosing_pump_2_total_cycles")
 
     assert hass.services.has_service(DOMAIN, SERVICE_DOSE_ML)
     assert hass.states.get(pump_2_sensor).state == "0.0"
+    assert hass.states.get(pump_2_lifetime_ml).state == "0.0"
+    assert hass.states.get(pump_2_lifetime_cycles).state == "0"
 
     await hass.services.async_call(
         DOMAIN,
@@ -396,6 +400,21 @@ async def test_manual_dose_service_updates_persisted_daily_total_sensor(
 
     assert client.dose_ml_calls == [(1, 2.5)]
     assert hass.states.get(pump_2_sensor).state == "2.5"
+    assert hass.states.get(pump_2_lifetime_ml).state == "2.5"
+    assert hass.states.get(pump_2_lifetime_cycles).state == "1"
+
+    # A second dose adds onto the lifetime counters and cycles increment per dose.
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_DOSE_ML,
+        {ATTR_ENTRY_ID: entry.entry_id, ATTR_PUMP: 2, ATTR_ML: 1.0},
+        blocking=True,
+    )
+    await _flush_ha_state_updates()
+
+    assert hass.states.get(pump_2_sensor).state == "3.5"
+    assert hass.states.get(pump_2_lifetime_ml).state == "3.5"
+    assert hass.states.get(pump_2_lifetime_cycles).state == "2"
 
 
 async def test_two_channel_dosing_pump_creates_two_sensors_and_rejects_pump_three(
@@ -413,6 +432,14 @@ async def test_two_channel_dosing_pump_creates_two_sensors_and_rejects_pump_thre
         SENSOR_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_dosing_pump_3_dosed_today"
     )
     assert pump_3_sensor is None
+    pump_3_total_ml = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_dosing_pump_3_total_ml"
+    )
+    pump_3_total_cycles = entity_registry.async_get_entity_id(
+        SENSOR_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_dosing_pump_3_total_cycles"
+    )
+    assert pump_3_total_ml is None
+    assert pump_3_total_cycles is None
 
     with pytest.raises(HomeAssistantError, match="has 2 pumps"):
         await hass.services.async_call(

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Callable, Mapping, Sequence
-from datetime import datetime
+from collections.abc import Callable
 from typing import Any
 
 import pytest
@@ -15,6 +14,8 @@ try:
         ATTR_BRIGHTNESS,
         ATTR_RGB_COLOR,
         ATTR_RGBW_COLOR,
+    )
+    from homeassistant.components.light import (
         DOMAIN as LIGHT_DOMAIN,
     )
     from homeassistant.config_entries import ConfigEntry, ConfigEntryState
@@ -35,8 +36,8 @@ except ImportError as err:
 
 from custom_components.chihiros.vendor.chihiros_led_control.models import (
     RGB_CHANNELS,
-    WRGB_CHANNELS,
     WHITE_CHANNELS,
+    WRGB_CHANNELS,
     DeviceModel,
 )
 from custom_components.chihiros.vendor.chihiros_led_control.protocol import ParsedNotification

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -1,0 +1,394 @@
+"""Integration tests for the unified RGB/RGBW light entity."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable, Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+import pytest
+
+try:
+    from homeassistant.components.bluetooth import update_coordinator as bluetooth_update
+    from homeassistant.components.light import (
+        ATTR_BRIGHTNESS,
+        ATTR_RGB_COLOR,
+        ATTR_RGBW_COLOR,
+        DOMAIN as LIGHT_DOMAIN,
+    )
+    from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+    from homeassistant.const import ATTR_ENTITY_ID, CONF_ADDRESS, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
+    from homeassistant.core import HomeAssistant
+    from homeassistant.helpers import entity_registry as er
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    import custom_components.chihiros as chihiros_integration
+    from custom_components.chihiros.const import DOMAIN
+    from custom_components.chihiros.coordinator import ChihirosDataUpdateCoordinator
+    from custom_components.chihiros.runtime import ChihirosRuntime
+except ImportError as err:
+    pytest.skip(
+        f"Home Assistant test group is not installed or is incompatible: {err}",
+        allow_module_level=True,
+    )
+
+from custom_components.chihiros.vendor.chihiros_led_control.models import (
+    RGB_CHANNELS,
+    WRGB_CHANNELS,
+    WHITE_CHANNELS,
+    DeviceModel,
+)
+from custom_components.chihiros.vendor.chihiros_led_control.protocol import ParsedNotification
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.asyncio,
+    pytest.mark.usefixtures("enable_custom_integrations", "mock_bluetooth"),
+]
+
+TEST_ADDRESS = "FA:CE:C0:00:10:02"
+
+
+class _TrackingClient:
+    """Minimal mock Chihiros client for RGB entity tests."""
+
+    def __init__(self, model: DeviceModel) -> None:
+        self.model = model
+        self.brightness_calls: list[Any] = []
+        self._callbacks: set[Callable[[ParsedNotification], None]] = set()
+
+    @property
+    def address(self) -> str:
+        return TEST_ADDRESS
+
+    @property
+    def name(self) -> str:
+        return "Test Chihiros"
+
+    @property
+    def model_name(self) -> str:
+        return self.model.name
+
+    @property
+    def colors(self) -> dict[str, int]:
+        return dict(self.model.color_channels)
+
+    def add_notification_callback(self, callback: Callable[[ParsedNotification], None]) -> Callable[[], None]:
+        self._callbacks.add(callback)
+
+        def remove() -> None:
+            self._callbacks.discard(callback)
+
+        return remove
+
+    async def set_brightness(self, brightness: Any) -> None:
+        self.brightness_calls.append(brightness)
+
+    async def query_status(self) -> None:
+        pass
+
+    async def disconnect(self) -> None:
+        pass
+
+
+WRGB_MODEL = DeviceModel("WRGB II Pro", ("DYWPRO30",), WRGB_CHANNELS)
+WHITE_MODEL = DeviceModel("A II", ("DYNA2",), WHITE_CHANNELS)
+
+
+async def _setup(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    model: DeviceModel,
+) -> tuple[ConfigEntry, _TrackingClient]:
+    """Set up the integration with a specific device model."""
+    client = _TrackingClient(model)
+
+    async def resolve_runtime(_hass: HomeAssistant, _entry: ConfigEntry) -> ChihirosRuntime:
+        return ChihirosRuntime(client=client, address=TEST_ADDRESS, always_available=True)
+
+    monkeypatch.setattr(chihiros_integration, "resolve_chihiros_runtime", resolve_runtime)
+    monkeypatch.setattr(bluetooth_update, "async_address_present", lambda *_a, **_k: True)
+    monkeypatch.setattr(ChihirosDataUpdateCoordinator, "async_start_bluetooth", lambda _self: None)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=client.name,
+        unique_id=TEST_ADDRESS,
+        data={CONF_ADDRESS: TEST_ADDRESS},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert entry.state is ConfigEntryState.LOADED
+    return entry, client
+
+
+async def _flush() -> None:
+    """Yield to pending state-write callbacks."""
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+
+# --- entity creation tests ---
+
+
+async def test_rgb_entity_created_for_rgb_device(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An RGB device gets a unified RGB light entity."""
+    _entry, _client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    assert entity_id is not None
+
+
+async def test_rgbw_entity_created_for_wrgb_device(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A WRGB device gets a unified RGBW light entity."""
+    _entry, _client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+
+async def test_no_rgb_entity_for_white_only_device(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A white-only device does not get an RGB entity."""
+    _entry, _client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+
+    rgb_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    rgbw_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert rgb_id is None
+    assert rgbw_id is None
+
+
+# --- turn_on / turn_off tests ---
+
+
+async def test_rgb_turn_on_with_rgb_color(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on with rgb_color sends all channels in one call."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0]},
+        blocking=True,
+    )
+    await _flush()
+
+    assert len(client.brightness_calls) == 1
+    call = client.brightness_calls[0]
+    assert isinstance(call, dict)
+    assert call["red"] == 100
+    assert call["green"] == 0
+    assert call["blue"] == 0
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+async def test_rgb_turn_on_with_brightness_scales_all_channels(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Brightness scales each channel proportionally."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 128, 0], ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    # scale_channel(255, 128) = ceil(255*128/255/255*100) = ceil(128/255*100) = 51
+    assert call["red"] == 51
+    # scale_channel(128, 128) = ceil(128*128/255/255*100) = 26
+    assert call["green"] == 26
+    assert call["blue"] == 0
+
+
+async def test_rgb_turn_on_without_color_defaults_to_white(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on without a color sends full-brightness white."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 100, "green": 100, "blue": 100}
+
+
+async def test_rgb_turn_off_zeros_all_channels(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning off sends zero for all channels."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 0, "green": 0, "blue": 0}
+
+
+# --- RGBW-specific tests ---
+
+
+async def test_rgbw_turn_on_with_rgbw_color(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on with rgbw_color sends all four channels."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: [255, 0, 0, 128]},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call["red"] == 100
+    assert call["green"] == 0
+    assert call["blue"] == 0
+    assert call["white"] == 51  # ceil(128/255*100)
+
+
+async def test_rgbw_turn_on_with_rgb_color_does_not_touch_white(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sending rgb_color to a WRGB entity only updates RGB channels."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0]},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    # HA converts rgb_color to rgbw_color with white=0 for RGBW entities
+    assert call == {"red": 100, "green": 0, "blue": 0, "white": 0}
+
+
+async def test_rgbw_turn_on_without_color_defaults_to_full_rgbw(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on without a color sends full-brightness RGBW."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 100, "green": 100, "blue": 100, "white": 100}
+
+
+async def test_rgbw_turn_off_zeros_all_four_channels(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning off a WRGB entity zeros all four channels."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_OFF,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 0, "green": 0, "blue": 0, "white": 0}
+
+
+async def test_rgbw_brightness_only_scales_all_channels(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Changing brightness without color scales all four channels."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw")
+    assert entity_id is not None
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    # default color is (255,255,255,255), all channels should scale equally
+    expected = 51  # ceil(128/255*100)
+    assert call["red"] == expected
+    assert call["green"] == expected
+    assert call["blue"] == expected
+    assert call["white"] == expected

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -19,9 +19,13 @@ try:
         DOMAIN as LIGHT_DOMAIN,
     )
     from homeassistant.config_entries import ConfigEntry, ConfigEntryState
-    from homeassistant.const import ATTR_ENTITY_ID, CONF_ADDRESS, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_ON
-    from homeassistant.core import HomeAssistant
+    from homeassistant.const import ATTR_ENTITY_ID, CONF_ADDRESS, SERVICE_TURN_OFF, SERVICE_TURN_ON, STATE_OFF, STATE_ON
+    from homeassistant.core import HomeAssistant, State
+    from homeassistant.exceptions import HomeAssistantError
     from homeassistant.helpers import entity_registry as er
+    from homeassistant.helpers.restore_state import StoredState
+    from homeassistant.helpers.restore_state import async_get as async_get_restore_data
+    from homeassistant.util import dt as dt_util
     from pytest_homeassistant_custom_component.common import MockConfigEntry
 
     import custom_components.chihiros as chihiros_integration
@@ -58,6 +62,7 @@ class _TrackingClient:
         self.model = model
         self.brightness_calls: list[Any] = []
         self._callbacks: set[Callable[[ParsedNotification], None]] = set()
+        self.set_brightness_exception: Exception | None = None
 
     @property
     def address(self) -> str:
@@ -84,6 +89,8 @@ class _TrackingClient:
         return remove
 
     async def set_brightness(self, brightness: Any) -> None:
+        if self.set_brightness_exception is not None:
+            raise self.set_brightness_exception
         self.brightness_calls.append(brightness)
 
     async def query_status(self) -> None:
@@ -101,12 +108,14 @@ async def _setup(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
     model: DeviceModel,
+    *,
+    always_available: bool = True,
 ) -> tuple[ConfigEntry, _TrackingClient]:
     """Set up the integration with a specific device model."""
     client = _TrackingClient(model)
 
     async def resolve_runtime(_hass: HomeAssistant, _entry: ConfigEntry) -> ChihirosRuntime:
-        return ChihirosRuntime(client=client, address=TEST_ADDRESS, always_available=True)
+        return ChihirosRuntime(client=client, address=TEST_ADDRESS, always_available=always_available)
 
     monkeypatch.setattr(chihiros_integration, "resolve_chihiros_runtime", resolve_runtime)
     monkeypatch.setattr(bluetooth_update, "async_address_present", lambda *_a, **_k: True)
@@ -130,6 +139,43 @@ async def _flush() -> None:
     """Yield to pending state-write callbacks."""
     await asyncio.sleep(0)
     await asyncio.sleep(0)
+
+
+def _entity_id(registry: er.EntityRegistry, suffix: str) -> str:
+    """Look up a light entity id by unique-id suffix and assert it exists."""
+    entity_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_{suffix}")
+    assert entity_id is not None
+    return entity_id
+
+
+def _prime_restore_state(hass: HomeAssistant, entity_id: str, state: State) -> None:
+    """Inject a stored last-state so the next entity load restores from it."""
+    async_get_restore_data(hass).last_states[entity_id] = StoredState(state, None, dt_util.utcnow())
+
+
+def _light_state(entity_id: str, is_on: bool = False, **attributes: Any) -> State:
+    """Build a restore-source State with the given attributes."""
+    return State(entity_id, STATE_ON if is_on else STATE_OFF, attributes)
+
+
+async def _reload_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    prime: Callable[[], None] | None = None,
+) -> None:
+    """Unload and re-setup a config entry so entities restore from stored state.
+
+    ``prime`` is called between unload and re-setup so callers can inject a
+    stored last-state (it must run after unload, because removing the entity
+    overwrites ``last_states[entity_id]`` with the entity's current state).
+    """
+    await hass.config_entries.async_unload(entry.entry_id)
+    await _flush()
+    if prime is not None:
+        prime()
+    await hass.config_entries.async_setup(entry.entry_id)
+    await _flush()
+    assert entry.state is ConfigEntryState.LOADED
 
 
 # --- entity creation tests ---
@@ -393,3 +439,394 @@ async def test_rgbw_brightness_only_scales_all_channels(
     assert call["green"] == expected
     assert call["blue"] == expected
     assert call["white"] == expected
+
+
+# --- brightness-only / scale edge cases ---
+
+
+async def test_rgb_brightness_only_scales_default_white(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Brightness without color scales the default (255,255,255) RGB color."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 51, "green": 51, "blue": 51}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 255, 255)
+
+
+async def test_rgb_scale_channel_zero_value(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 0 channel value stays 0 through the brightness scaling."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [0, 128, 255]},
+        blocking=True,
+    )
+    await _flush()
+
+    call = client.brightness_calls[-1]
+    assert call == {"red": 0, "green": 51, "blue": 100}
+    state = hass.states.get(entity_id)
+    assert state.attributes[ATTR_RGB_COLOR] == (0, 128, 255)
+
+
+# --- error paths ---
+
+
+async def test_rgb_turn_on_set_brightness_failure_raises_and_marks_unavailable(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BLE failure during turn_on raises HomeAssistantError and clears availability."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    client.set_brightness_exception = RuntimeError("ble write failed")
+
+    with pytest.raises(HomeAssistantError, match="Failed to set brightness"):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0]},
+            blocking=True,
+        )
+    await _flush()
+
+    # is_on must not have flipped to ON after the failed write
+    assert hass.states.get(entity_id).state != STATE_ON
+
+
+async def test_rgb_turn_off_set_brightness_failure_raises_and_marks_unavailable(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A BLE failure during turn_off raises HomeAssistantError and clears availability."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    # Turn on successfully first so we have a known state.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0]},
+        blocking=True,
+    )
+    await _flush()
+
+    client.set_brightness_exception = RuntimeError("ble write failed")
+
+    with pytest.raises(HomeAssistantError, match="Failed to turn off"):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_OFF,
+            {ATTR_ENTITY_ID: entity_id},
+            blocking=True,
+        )
+    await _flush()
+
+    # is_on must not have flipped to off after the failed write
+    assert hass.states.get(entity_id).state == STATE_ON
+
+
+# --- white-only per-channel entity (ChihirosLightEntity) ---
+
+
+async def test_white_only_device_creates_per_channel_light_entity(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A white-only device gets a single per-channel brightness entity."""
+    _entry, _client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+
+    white_id = registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_white")
+    assert white_id is not None
+    # No unified RGB/RGBW entity for white-only devices
+    assert registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgb") is None
+    assert registry.async_get_entity_id(LIGHT_DOMAIN, DOMAIN, f"{TEST_ADDRESS}_rgbw") is None
+
+
+async def test_white_turn_on_with_brightness_scales_to_device_level(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-channel white entity maps 0-255 brightness to 1-100 device level."""
+    _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+
+    assert client.brightness_calls[-1] == {"white": 51}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+
+
+async def test_white_turn_on_without_brightness_defaults_to_full(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on without brightness sends 100 to the device and reports 255."""
+    _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id},
+        blocking=True,
+    )
+    await _flush()
+
+    assert client.brightness_calls[-1] == {"white": 100}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+
+
+async def test_white_turn_off_zeros_channel(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning off a white entity sends 0 to the device channel."""
+    _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 200},
+        blocking=True,
+    )
+    await _flush()
+
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    assert client.brightness_calls[-1] == {"white": 0}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_white_turn_on_set_brightness_failure_raises_homeassistant_error(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A per-channel entity raises HomeAssistantError and clears availability on BLE failure."""
+    _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    client.set_brightness_exception = RuntimeError("ble write failed")
+
+    with pytest.raises(HomeAssistantError, match="Failed to set brightness"):
+        await hass.services.async_call(
+            LIGHT_DOMAIN,
+            SERVICE_TURN_ON,
+            {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+            blocking=True,
+        )
+    await _flush()
+
+    # is_on must not have flipped to ON after the failed turn_on
+    assert hass.states.get(entity_id).state != STATE_ON
+
+
+# --- restore-state tests ---
+
+
+async def test_rgb_entity_restores_color_and_brightness_from_last_state(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unified RGB entity restores rgb_color and brightness on reload."""
+    entry, _client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            _light_state(entity_id, is_on=True, brightness=120, rgb_color=[10, 20, 30]),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 120
+    assert state.attributes[ATTR_RGB_COLOR] == (10, 20, 30)
+
+
+async def test_rgbw_entity_restores_rgbw_color_from_last_state(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unified RGBW entity restores rgbw_color (and rgb mirror) on reload."""
+    entry, _client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgbw")
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            _light_state(
+                entity_id,
+                is_on=True,
+                brightness=180,
+                rgb_color=[15, 25, 35],
+                rgbw_color=[15, 25, 35, 45],
+            ),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 180
+    assert state.attributes[ATTR_RGBW_COLOR] == (15, 25, 35, 45)
+
+
+async def test_white_entity_restores_brightness_and_on_state_from_last_state(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-channel white entity restores brightness and on/off on reload."""
+    entry, _client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            _light_state(entity_id, is_on=True, brightness=77),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 77
+
+
+async def test_rgb_entity_restore_off_state_when_last_state_off(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring from an OFF last state keeps the entity off."""
+    entry, _client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            _light_state(entity_id, is_on=False, brightness=50, rgb_color=[100, 100, 100]),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_OFF
+
+
+async def test_rgb_entity_restore_without_color_keeps_default_color(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Restoring only brightness (no color attributes) keeps the default color."""
+    entry, _client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await _reload_entry(
+        hass,
+        entry,
+        prime=lambda: _prime_restore_state(
+            hass,
+            entity_id,
+            _light_state(entity_id, is_on=True, brightness=200),
+        ),
+    )
+
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 200
+    # No rgb_color in the restore source, so the constructor default is kept.
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 255, 255)
+
+
+# --- availability (not always available) ---
+
+
+async def test_white_entity_available_when_not_always_available(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The per-channel entity delegates to coordinator availability when not always available."""
+    _entry, _client = await _setup(hass, monkeypatch, WHITE_MODEL, always_available=False)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await _flush()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != "unavailable"
+
+
+async def test_rgb_entity_available_when_not_always_available(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The unified RGB entity delegates to coordinator availability when not always available."""
+    _entry, _client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS), always_available=False)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    await _flush()
+
+    state = hass.states.get(entity_id)
+    assert state is not None
+    assert state.state != "unavailable"

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,149 @@
+"""Tests for Chihiros sensor formatting and notification-sensor error handling."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Callable
+
+import pytest
+
+try:
+    from homeassistant.components.bluetooth import update_coordinator as bluetooth_update
+    from homeassistant.components.sensor import DOMAIN as SENSOR_DOMAIN
+    from homeassistant.config_entries import ConfigEntry, ConfigEntryState
+    from homeassistant.const import CONF_ADDRESS
+    from homeassistant.core import HomeAssistant
+    from homeassistant.exceptions import HomeAssistantError
+    from homeassistant.helpers import entity_registry as er
+    from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+    import custom_components.chihiros as chihiros_integration
+    from custom_components.chihiros.const import DOMAIN
+    from custom_components.chihiros.coordinator import ChihirosDataUpdateCoordinator
+    from custom_components.chihiros.runtime import ChihirosRuntime
+    from custom_components.chihiros.sensor import (
+        _format_schedule_point,
+        _format_schedule_state,
+    )
+except ImportError as err:
+    pytest.skip(
+        f"Home Assistant test group is not installed or is incompatible: {err}",
+        allow_module_level=True,
+    )
+
+from custom_components.chihiros.vendor.chihiros_led_control.models import RGB_CHANNELS, DeviceModel
+from custom_components.chihiros.vendor.chihiros_led_control.protocol import ParsedNotification
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.usefixtures("enable_custom_integrations", "mock_bluetooth"),
+]
+
+_ASYNC_TESTS = pytest.mark.asyncio
+
+MAX_SENSOR_STATE_LENGTH = 255
+
+
+def test_format_schedule_state_covers_branches() -> None:
+    """All schedule formatting branches produce readable state strings."""
+    # empty -> No schedule
+    assert _format_schedule_state(()) == "No schedule"
+
+    # uniform levels collapse to "<time> <level>%"
+    assert _format_schedule_point({"time": "08:05", "levels": {"red": 10, "blue": 10}}) == "08:05 10%"
+
+    # distinct per-channel levels render as "<color initial><level>/..."
+    assert _format_schedule_point({"time": "09:00", "levels": {"red": 10, "green": 20, "blue": 30}}) == (
+        "09:00 R10/G20/B30"
+    )
+
+    # missing/invalid levels falls back to the time string
+    assert _format_schedule_point({"time": "10:00", "levels": {}}) == "10:00"
+    assert _format_schedule_point({"levels": {}}) == "unknown"
+
+
+def test_format_schedule_state_truncates_long_payload() -> None:
+    """A schedule string longer than the sensor max collapses to a count."""
+    many_points = tuple({"time": "12:00", "levels": {"red": 50, "green": 50, "blue": 50}} for _ in range(200))
+    state = _format_schedule_state(many_points)
+    assert state == f"{len(many_points)} points"
+    assert len(_format_schedule_state(many_points[:2])) <= MAX_SENSOR_STATE_LENGTH
+
+
+# --- integration: notification sensor async_update error path ---
+
+
+class _FailingQueryClient:
+    """Minimal client whose query_status always fails."""
+
+    def __init__(self) -> None:
+        self.model = DeviceModel("Test RGB", ("TEST-RGB",), RGB_CHANNELS)
+        self._callbacks: set[Callable[[ParsedNotification], None]] = set()
+
+    @property
+    def address(self) -> str:
+        return "FA:CE:C0:00:40:01"
+
+    @property
+    def name(self) -> str:
+        return "Test Chihiros"
+
+    @property
+    def model_name(self) -> str:
+        return self.model.name
+
+    @property
+    def colors(self) -> dict[str, int]:
+        return dict(self.model.color_channels)
+
+    def add_notification_callback(self, callback: Callable[[ParsedNotification], None]) -> Callable[[], None]:
+        self._callbacks.add(callback)
+
+        def remove() -> None:
+            self._callbacks.discard(callback)
+
+        return remove
+
+    async def query_status(self) -> None:
+        raise RuntimeError("device offline")
+
+    async def disconnect(self) -> None:
+        pass
+
+
+@_ASYNC_TESTS
+async def test_notification_sensor_async_update_raises_homeassistant_error(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failing status request surfaces as HomeAssistantError from async_update."""
+    client = _FailingQueryClient()
+    address = client.address
+
+    async def resolve_runtime(_hass: HomeAssistant, _entry: ConfigEntry) -> ChihirosRuntime:
+        return ChihirosRuntime(client=client, address=address, always_available=True)
+
+    monkeypatch.setattr(chihiros_integration, "resolve_chihiros_runtime", resolve_runtime)
+    monkeypatch.setattr(bluetooth_update, "async_address_present", lambda *_a, **_k: True)
+    monkeypatch.setattr(ChihirosDataUpdateCoordinator, "async_start_bluetooth", lambda _self: None)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        title=client.name,
+        unique_id=address,
+        data={CONF_ADDRESS: address},
+    )
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+    assert entry.state is ConfigEntryState.LOADED
+
+    registry = er.async_get(hass)
+    sensor_id = registry.async_get_entity_id(SENSOR_DOMAIN, DOMAIN, f"{address}_last_notification")
+    assert sensor_id is not None
+    entity = hass.data[SENSOR_DOMAIN].get_entity(sensor_id)
+    assert entity is not None
+
+    with pytest.raises(HomeAssistantError, match="Failed to request status"):
+        await entity.async_update()


### PR DESCRIPTION
Expose a single light entity per device that sets all color channels simultaneously in one BLE transaction. This avoids packet collisions that occur when per-channel entities are triggered in parallel from Home Assistant automations.

- RGB-only devices get a ColorMode.RGB entity
- WRGB devices get a ColorMode.RGBW entity with independent white control
- White-only devices are unaffected (no RGB entity created)

Closes #105