### PR TITLE
fix: keep light state consistent on failed writes

### DIFF
--- a/custom_components/chihiros/fan.py
+++ b/custom_components/chihiros/fan.py
@@ -119,11 +119,8 @@ class ChihirosFanEntity(
         await self.async_set_percentage(0)
 
     async def _set_fan_speed(self, percentage: int) -> None:
-        """Send the fan speed command and keep availability in sync."""
+        """Send the fan speed command and raise on BLE failure."""
         try:
             await self._device.set_fan_speed(percentage)
         except Exception as ex:
-            self._attr_available = False
-            self.schedule_update_ha_state()
             raise HomeAssistantError(f"Failed to set fan speed for {self.name}") from ex
-        self._attr_available = True

--- a/custom_components/chihiros/light.py
+++ b/custom_components/chihiros/light.py
@@ -135,9 +135,13 @@ class ChihirosLightEntity(
             await self._set_entity_brightness(brightness)
             self._attr_brightness = hass_brightness
         else:
-            _LOGGER.debug("Turning on: %s", self.name)
-            await self._set_entity_brightness(100)
-            self._attr_brightness = 255
+            # Restore the last known brightness instead of snapping to full,
+            # so toggling off/on keeps the previous level.
+            hass_brightness = self._attr_brightness or 255
+            brightness = max(1, math.ceil((hass_brightness / 255) * 100))
+            _LOGGER.debug("Turning on: %s to %s", self.name, brightness)
+            await self._set_entity_brightness(brightness)
+            self._attr_brightness = hass_brightness
         self._attr_is_on = True
         self.schedule_update_ha_state()
         _LOGGER.debug("Turned on: %s", self.name)
@@ -147,19 +151,16 @@ class ChihirosLightEntity(
         _LOGGER.debug("Turning off: %s", self.name)
         await self._set_entity_brightness(0)
         self._attr_is_on = False
-        self._attr_brightness = 0
+        # Keep _attr_brightness at its last level so toggling back on restores it.
         self.schedule_update_ha_state()
         _LOGGER.debug("Turned off: %s", self.name)
 
     async def _set_entity_brightness(self, brightness: int) -> None:
-        """Set brightness and keep Home Assistant availability in sync."""
+        """Set brightness and raise on BLE failure."""
         try:
             await self._device.set_brightness({self._color: brightness})
         except Exception as ex:
-            self._attr_available = False
-            self.schedule_update_ha_state()
             raise HomeAssistantError(f"Failed to set brightness for {self.name}") from ex
-        self._attr_available = True
         self.coordinator.async_set_auto_mode(False)
 
 
@@ -243,28 +244,29 @@ class ChihirosRGBLightEntity(
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Instruct the light to turn on."""
-        master_brightness = kwargs.get(ATTR_BRIGHTNESS, self._attr_brightness or 255)
-        self._attr_brightness = int(master_brightness)
+        master_brightness = int(kwargs.get(ATTR_BRIGHTNESS, self._attr_brightness or 255))
 
         if ATTR_RGBW_COLOR in kwargs and self._has_white:
-            r, g, b, w = (int(c) for c in kwargs[ATTR_RGBW_COLOR])
-            self._attr_rgbw_color = (r, g, b, w)
-            self._attr_rgb_color = (r, g, b)
-            await self._set_rgb_brightness((r, g, b, w), self._attr_brightness)
+            color: tuple[int, ...] = tuple(int(c) for c in kwargs[ATTR_RGBW_COLOR])
         elif ATTR_RGB_COLOR in kwargs:
             # Home Assistant converts rgb_color -> rgbw_color (white=0) for
             # RGBW entities, so this branch is only reached on pure RGB models.
-            r, g, b = (int(c) for c in kwargs[ATTR_RGB_COLOR])
-            self._attr_rgb_color = (r, g, b)
-            await self._set_rgb_brightness((r, g, b), self._attr_brightness)
+            color = tuple(int(c) for c in kwargs[ATTR_RGB_COLOR])
+        elif self._has_white:
+            color = self._attr_rgbw_color or (255, 255, 255, 255)
         else:
-            if self._has_white:
-                color = self._attr_rgbw_color or (255, 255, 255, 255)
-                await self._set_rgb_brightness(color, self._attr_brightness)
-            else:
-                color = self._attr_rgb_color or (255, 255, 255)
-                await self._set_rgb_brightness(color, self._attr_brightness)
+            color = self._attr_rgb_color or (255, 255, 255)
 
+        # Write to the device before persisting any state attributes, so a
+        # failed write never leaves the reported state out of sync with the
+        # physical light.
+        await self._set_rgb_brightness(color, master_brightness)
+        self._attr_brightness = master_brightness
+        if self._has_white:
+            self._attr_rgbw_color = color
+            self._attr_rgb_color = color[:3]
+        else:
+            self._attr_rgb_color = color
         self._attr_is_on = True
         self.schedule_update_ha_state()
         _LOGGER.debug("Turned on: %s", self.name)
@@ -276,12 +278,9 @@ class ChihirosRGBLightEntity(
         try:
             await self._device.set_brightness(channels)
         except Exception as ex:
-            self._attr_available = False
-            self.schedule_update_ha_state()
             raise HomeAssistantError(f"Failed to turn off {self.name}") from ex
-        self._attr_available = True
         self._attr_is_on = False
-        self._attr_brightness = 0
+        # Keep _attr_brightness at its last level so toggling back on restores it.
         self.coordinator.async_set_auto_mode(False)
         self.schedule_update_ha_state()
         _LOGGER.debug("Turned off: %s", self.name)
@@ -318,8 +317,5 @@ class ChihirosRGBLightEntity(
         try:
             await self._device.set_brightness(channels)
         except Exception as ex:
-            self._attr_available = False
-            self.schedule_update_ha_state()
             raise HomeAssistantError(f"Failed to set brightness for {self.name}") from ex
-        self._attr_available = True
         self.coordinator.async_set_auto_mode(False)

--- a/custom_components/chihiros/manifest.json
+++ b/custom_components/chihiros/manifest.json
@@ -96,5 +96,5 @@
   "iot_class": "assumed_state",
   "issue_tracker": "https://github.com/TheMicDiet/chihiros-led-control/issues",
   "requirements": [],
-  "version": "0.13.0"
+  "version": "0.13.1"
 }

--- a/tests/test_light_rgb.py
+++ b/tests/test_light_rgb.py
@@ -492,17 +492,85 @@ async def test_rgb_scale_channel_zero_value(
     assert state.attributes[ATTR_RGB_COLOR] == (0, 128, 255)
 
 
-# --- error paths ---
-
-
-async def test_rgb_turn_on_set_brightness_failure_raises_and_marks_unavailable(
+async def test_rgb_toggle_off_on_restores_last_brightness(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A BLE failure during turn_on raises HomeAssistantError and clears availability."""
+    """Turning on without brightness after a turn-off restores the last level."""
     _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
     registry = er.async_get(hass)
     entity_id = _entity_id(registry, "rgb")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0], ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    # scale_channel(255, 128) = ceil(128/255*100) = 51
+    assert client.brightness_calls[-1] == {"red": 51, "green": 0, "blue": 0}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
+
+
+async def test_rgbw_toggle_off_on_restores_rgbw_color_and_brightness(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on without color after a turn-off restores rgbw color and level."""
+    _entry, client = await _setup(hass, monkeypatch, WRGB_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgbw")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGBW_COLOR: [255, 0, 0, 0], ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    assert client.brightness_calls[-1] == {"red": 51, "green": 0, "blue": 0, "white": 0}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGBW_COLOR] == (255, 0, 0, 0)
+
+
+# --- error paths ---
+
+
+async def test_rgb_turn_on_set_brightness_failure_keeps_state_consistent(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed color change raises and keeps the previously applied state."""
+    _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "rgb")
+
+    # Establish a known on state first.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0], ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
 
     client.set_brightness_exception = RuntimeError("ble write failed")
 
@@ -510,20 +578,24 @@ async def test_rgb_turn_on_set_brightness_failure_raises_and_marks_unavailable(
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [255, 0, 0]},
+            {ATTR_ENTITY_ID: entity_id, ATTR_RGB_COLOR: [0, 255, 0]},
             blocking=True,
         )
     await _flush()
 
-    # is_on must not have flipped to ON after the failed write
-    assert hass.states.get(entity_id).state != STATE_ON
+    # The entity must still report the previously applied color and brightness
+    # instead of the color that was never written to the device.
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
 
 
-async def test_rgb_turn_off_set_brightness_failure_raises_and_marks_unavailable(
+async def test_rgb_turn_off_set_brightness_failure_keeps_state_on(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A BLE failure during turn_off raises HomeAssistantError and clears availability."""
+    """A BLE failure during turn_off raises HomeAssistantError and keeps the entity on."""
     _entry, client = await _setup(hass, monkeypatch, DeviceModel("Test RGB", (), RGB_CHANNELS))
     registry = er.async_get(hass)
     entity_id = _entity_id(registry, "rgb")
@@ -548,8 +620,11 @@ async def test_rgb_turn_off_set_brightness_failure_raises_and_marks_unavailable(
         )
     await _flush()
 
-    # is_on must not have flipped to off after the failed write
-    assert hass.states.get(entity_id).state == STATE_ON
+    # is_on and the reported brightness/color must be unchanged after the failed write
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 255
+    assert state.attributes[ATTR_RGB_COLOR] == (255, 0, 0)
 
 
 # --- white-only per-channel entity (ChihirosLightEntity) ---
@@ -641,14 +716,23 @@ async def test_white_turn_off_zeros_channel(
     assert state.state == STATE_OFF
 
 
-async def test_white_turn_on_set_brightness_failure_raises_homeassistant_error(
+async def test_white_turn_on_set_brightness_failure_keeps_state_consistent(
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """A per-channel entity raises HomeAssistantError and clears availability on BLE failure."""
+    """A failed brightness change raises and keeps the previously applied level."""
     _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
     registry = er.async_get(hass)
     entity_id = _entity_id(registry, "white")
+
+    # Establish a known on state first.
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+        blocking=True,
+    )
+    await _flush()
 
     client.set_brightness_exception = RuntimeError("ble write failed")
 
@@ -656,13 +740,44 @@ async def test_white_turn_on_set_brightness_failure_raises_homeassistant_error(
         await hass.services.async_call(
             LIGHT_DOMAIN,
             SERVICE_TURN_ON,
-            {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 128},
+            {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 200},
             blocking=True,
         )
     await _flush()
 
-    # is_on must not have flipped to ON after the failed turn_on
-    assert hass.states.get(entity_id).state != STATE_ON
+    # Brightness must remain at the previously applied level.
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 128
+
+
+async def test_white_toggle_off_on_restores_last_brightness(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Turning on without brightness after a turn-off restores the last level."""
+    _entry, client = await _setup(hass, monkeypatch, WHITE_MODEL)
+    registry = er.async_get(hass)
+    entity_id = _entity_id(registry, "white")
+
+    await hass.services.async_call(
+        LIGHT_DOMAIN,
+        SERVICE_TURN_ON,
+        {ATTR_ENTITY_ID: entity_id, ATTR_BRIGHTNESS: 200},
+        blocking=True,
+    )
+    await _flush()
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_OFF, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    await hass.services.async_call(LIGHT_DOMAIN, SERVICE_TURN_ON, {ATTR_ENTITY_ID: entity_id}, blocking=True)
+    await _flush()
+
+    # ceil(200/255*100) = 79
+    assert client.brightness_calls[-1] == {"white": 79}
+    state = hass.states.get(entity_id)
+    assert state.state == STATE_ON
+    assert state.attributes[ATTR_BRIGHTNESS] == 200
 
 
 # --- restore-state tests ---


### PR DESCRIPTION
## Summary
- keep RGB/RGBW and per-channel light state unchanged when BLE writes fail
- restore the previous brightness when toggling lights off and on
- remove ineffective availability mutations from light and fan write paths
- bump the custom integration version to 0.13.1

## Validation
- ============================= test session starts ==============================
platform linux -- Python 3.14.6, pytest-9.0.0, pluggy-1.6.0
rootdir: /home/michael/git/chihiros-led-control
configfile: pyproject.toml
plugins: respx-0.22.0, cov-7.0.0, timeout-2.4.0, anyio-4.14.0, aiohttp-1.1.0, unordered-0.7.0, asyncio-1.3.0, pytest_freezer-0.4.9, homeassistant-custom-component-0.13.299, xdist-3.8.0, requests-mock-1.12.1, picked-0.5.1, sugar-1.0.0, syrupy-5.0.0, socket-0.7.0, github-actions-annotate-failures-0.3.0
asyncio: mode=Mode.AUTO, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 181 items

tests/test_cli.py ..........                                             [  5%]
tests/test_client.py .......................                             [ 18%]
tests/test_coordinator.py ......                                         [ 21%]
tests/test_dosing.py .........                                           [ 26%]
tests/test_factory.py ...........                                        [ 32%]
tests/test_fan.py ......                                                 [ 35%]
tests/test_home_assistant_integration.py ..........                      [ 41%]
tests/test_home_assistant_unit.py ...............................        [ 58%]
tests/test_light_rgb.py ...............................                  [ 75%]
tests/test_manifest_requirements.py .                                    [ 76%]
tests/test_protocol.py ................................                  [ 93%]
tests/test_schedule_validation.py ....                                   [ 96%]
tests/test_sensor.py ...                                                 [ 97%]
tests/test_sync_vendor.py ..                                             [ 98%]
tests/test_weekday_encoding.py ..                                        [100%]

============================= 181 passed in 1.97s ==============================
- trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check docstring is first.................................................Passed
check yaml...............................................................Passed
check yaml...........................................(no files to check)Skipped
check toml...............................................................Passed
debug statements (python)................................................Passed
check python ast.........................................................Passed
ruff check...............................................................Passed
ruff format..............................................................Passed
sync vendor check........................................................Passed
doc8.................................................(no files to check)Skipped
- Vendored chihiros_led_control package is up to date.
